### PR TITLE
fix: github_copilot_sdk.py - prioritize BYOK_MODELS over API fetch when explicitly configured

### DIFF
--- a/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
+++ b/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
@@ -8133,7 +8133,15 @@ class Pipe:
         ) or self.valves.BYOK_BEARER_TOKEN
         effective_models = (uv.BYOK_MODELS if uv else "") or self.valves.BYOK_MODELS
 
-        if effective_base_url:
+        # If user explicitly configured BYOK_MODELS, use them directly (skip API fetch)
+        if effective_models.strip():
+            model_list = [
+                m.strip() for m in effective_models.split(",") if m.strip()
+            ]
+            await self._emit_debug_log(
+                f"BYOK: Using user-configured BYOK_MODELS ({len(model_list)} models)."
+            )
+        elif effective_base_url:
             try:
                 base_url = effective_base_url.rstrip("/")
                 url = f"{base_url}/models"
@@ -8187,16 +8195,6 @@ class Pipe:
                             await asyncio.sleep(1)
             except Exception as e:
                 await self._emit_debug_log(f"BYOK: Setup error: {e}")
-
-        # Fallback to configured list or defaults
-        if not model_list:
-            if effective_models.strip():
-                model_list = [
-                    m.strip() for m in effective_models.split(",") if m.strip()
-                ]
-                await self._emit_debug_log(
-                    f"BYOK: Using user-configured BYOK_MODELS ({len(model_list)} models)."
-                )
 
         # Infer per-model provider from ID string (BYOK endpoints can return multi-provider lists)
         byok_models = [


### PR DESCRIPTION
## Summary

- Prioritize `BYOK_MODELS` over API fetch when explicitly configured — if a user sets `BYOK_MODELS`, the plugin now uses that list directly and skips the `/models` API call to `BYOK_BASE_URL`
- Remove the now-redundant fallback block that parsed `BYOK_MODELS` only after API fetch failed

## Behavior Change

| Scenario | Before | After |
|---|---|---|
| Only `BYOK_BASE_URL` set | API fetch | API fetch |
| Both set | API fetch **first**, fallback to `BYOK_MODELS` on failure | `BYOK_MODELS` **first**, API fetch skipped |
| Neither set | Empty list | Empty list |

**Breaking change for users who have both `BYOK_BASE_URL` and `BYOK_MODELS` configured:** the dynamic model list from API fetch will no longer be used. If you want the API-fetched list, clear `BYOK_MODELS`.

## Test Plan
- [x] Configure only `BYOK_BASE_URL` — verify models are fetched via API as before
- [x] Configure both `BYOK_MODELS` and `BYOK_BASE_URL` — verify `BYOK_MODELS` takes precedence
