### PR TITLE
fix: github-copilot-sdk version & Mode import error (closes #79)

### DIFF
--- a/plugins/pipes/github-copilot-sdk/debug/test_system_message_resume.py
+++ b/plugins/pipes/github-copilot-sdk/debug/test_system_message_resume.py
@@ -187,9 +187,12 @@ async def main():
     cli_path = os.environ.get("COPILOT_CLI_PATH")
     client_config = {"log_level": "info"}
     if cli_path:
-        client_config["cli_path"] = cli_path
+        # copilot-sdk >= 1.0: cli_path is expressed via a StdioRuntimeConnection.
+        from copilot.client import StdioRuntimeConnection
 
-    client = CopilotClient(client_config)
+        client_config["connection"] = StdioRuntimeConnection(path=cli_path)
+
+    client = CopilotClient(**client_config)
 
     try:
         await client.start()
@@ -355,9 +358,12 @@ async def main_byok():
     cli_path = os.environ.get("COPILOT_CLI_PATH")
     client_config = {"log_level": "info"}
     if cli_path:
-        client_config["cli_path"] = cli_path
+        # copilot-sdk >= 1.0: cli_path is expressed via a StdioRuntimeConnection.
+        from copilot.client import StdioRuntimeConnection
 
-    client = CopilotClient(client_config)
+        client_config["connection"] = StdioRuntimeConnection(path=cli_path)
+
+    client = CopilotClient(**client_config)
 
     try:
         await client.start()

--- a/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
+++ b/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
@@ -6,7 +6,7 @@ funding_url: https://github.com/open-webui
 openwebui_id: ce96f7b4-12fc-4ac3-9a01-875713e69359
 description: A powerful Agent SDK integration for OpenWebUI. It deeply bridges GitHub Copilot SDK with OpenWebUI's ecosystem, enabling the Agent to autonomously perform intent recognition, web search, and context compaction. It seamlessly reuses your existing Tools, MCP servers, OpenAPI servers, and Skills for a professional, full-featured experience.
 version: 0.13.2
-requirements: github-copilot-sdk==0.2.2
+requirements: github-copilot-sdk==1.0.2
 """
 
 import asyncio
@@ -35,7 +35,8 @@ from typing import Any, AsyncGenerator, Dict, List, Literal, Optional, Tuple, Un
 
 import aiohttp
 from copilot import CopilotClient, define_tool
-from copilot.generated.rpc import Mode, SessionModeSetParams
+# copilot-sdk >= 1.0 renamed: Mode -> SessionMode, SessionModeSetParams -> ModeSetRequest
+from copilot.generated.rpc import ModeSetRequest, SessionMode
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field, create_model
 
@@ -7303,16 +7304,28 @@ class Pipe:
         chat_id: Optional[str] = None,
         token: Optional[str] = None,
     ):
-        """Build CopilotClient config from valves and request body."""
-        from copilot import SubprocessConfig
+        """Build CopilotClient config from valves and request body.
+
+        Returns a dict of kwargs suitable for ``CopilotClient(**client_config)``.
+        copilot-sdk >= 1.0 removed ``SubprocessConfig``; the equivalent options are
+        now passed directly to ``CopilotClient`` (``working_directory``, ``env``,
+        ``github_token``, ``log_level``) and the CLI path is expressed via a
+        ``StdioRuntimeConnection``.
+        """
+        from copilot.client import StdioRuntimeConnection
 
         cwd = self._get_workspace_dir(user_id=user_id, chat_id=chat_id)
         config_dir = self._get_copilot_config_dir()
 
         client_config = {}
+        # copilot-sdk >= 1.0: cli_path is now expressed via a RuntimeConnection.
+        # When COPILOT_CLI_PATH is unset, pass connection=None so the SDK uses the
+        # bundled binary (same default behaviour as the old SubprocessConfig()).
         if os.environ.get("COPILOT_CLI_PATH"):
-            client_config["cli_path"] = os.environ["COPILOT_CLI_PATH"]
-        client_config["cwd"] = cwd
+            client_config["connection"] = StdioRuntimeConnection(
+                path=os.environ["COPILOT_CLI_PATH"]
+            )
+        client_config["working_directory"] = cwd
         client_config["github_token"] = token
 
         if self.valves.LOG_LEVEL:
@@ -7372,7 +7385,7 @@ class Pipe:
 
         client_config["env"] = agent_env
 
-        return SubprocessConfig(**client_config)
+        return client_config
 
     # ==================== Agent Team Helpers ====================
 
@@ -7807,7 +7820,9 @@ class Pipe:
         session_mode: str = "autopilot",
     ):
         """Build SessionConfig for Copilot SDK."""
-        from copilot.session import InfiniteSessionConfig, SessionConfig
+        # copilot-sdk >= 1.0 removed SessionConfig; this method returns a plain
+        # dict of kwargs that is unpacked into client.create_session(**params).
+        from copilot.session import InfiniteSessionConfig
 
         infinite_session_config = None
         if self.valves.INFINITE_SESSION:
@@ -7848,7 +7863,7 @@ class Pipe:
             "streaming": is_streaming,
             "tools": custom_tools,
             "system_message": system_message_config,
-            "config_dir": self._get_copilot_config_dir(),
+            "config_directory": self._get_copilot_config_dir(),
             "infinite_sessions": infinite_session_config,
             "working_directory": resolved_cwd,
         }
@@ -8438,7 +8453,10 @@ class Pipe:
             client = self.__class__._shared_clients.get(token_hash)
             if client:
                 try:
-                    state = client.get_state()
+                    # copilot-sdk >= 1.0 removed the public get_state(); the
+                    # equivalent connection state lives on the private _state
+                    # attribute ("disconnected"|"connecting"|"connected"|"error").
+                    state = getattr(client, "_state", "disconnected")
                     if state == "connected":
                         return client
                     if state == "error":
@@ -8459,7 +8477,9 @@ class Pipe:
                 user_id=None, chat_id=None, token=token
             )
 
-            new_client = CopilotClient(client_config, auto_start=True)
+            # copilot-sdk >= 1.0: CopilotClient takes kwargs directly (no
+            # SubprocessConfig, no auto_start). start() is awaited below.
+            new_client = CopilotClient(**client_config)
             await new_client.start()
             self.__class__._shared_clients[token_hash] = new_client
             return new_client
@@ -9193,7 +9213,8 @@ class Pipe:
         client_config = self._build_client_config(
             user_id=user_id, chat_id=chat_id, token=effective_token
         )
-        client = CopilotClient(client_config)
+        # copilot-sdk >= 1.0: CopilotClient takes kwargs directly.
+        client = CopilotClient(**client_config)
         should_stop_client = True
         try:
             await client.start()
@@ -9298,7 +9319,7 @@ class Pipe:
                         "model": real_model_id,
                         "streaming": is_streaming,
                         "tools": custom_tools,
-                        "config_dir": self._get_copilot_config_dir(),
+                        "config_directory": self._get_copilot_config_dir(),
                     }
 
                     permission_request_handler = getattr(
@@ -9416,9 +9437,9 @@ class Pipe:
                     # The system prompt already carries the active-mode directive, so this
                     # is an additional SDK-level hint.  A 5-second timeout prevents hangs.
                     try:
-                        mode_enum = Mode(effective_session_mode)
+                        mode_enum = SessionMode(effective_session_mode)
                         await asyncio.wait_for(
-                            session.rpc.mode.set(SessionModeSetParams(mode=mode_enum)),
+                            session.rpc.mode.set(ModeSetRequest(mode=mode_enum)),
                             timeout=5.0,
                         )
                         logger.info(
@@ -9500,9 +9521,9 @@ class Pipe:
                 # The system prompt already carries the active-mode directive, so this
                 # is an additional SDK-level hint.  A 5-second timeout prevents hangs.
                 try:
-                    mode_enum = Mode(effective_session_mode)
+                    mode_enum = SessionMode(effective_session_mode)
                     await asyncio.wait_for(
-                        session.rpc.mode.set(SessionModeSetParams(mode=mode_enum)),
+                        session.rpc.mode.set(ModeSetRequest(mode=mode_enum)),
                         timeout=5.0,
                     )
                     logger.info(

--- a/plugins/pipes/github-copilot-sdk/scripts/sync_to_workspace.py
+++ b/plugins/pipes/github-copilot-sdk/scripts/sync_to_workspace.py
@@ -16,7 +16,7 @@ except ImportError:
 try:
     from copilot import CopilotClient
 except ImportError:
-    print("❌ 错误: 无法导入 copilot SDK。请运行: pip install github-copilot-sdk==0.1.23")
+    print("❌ 错误: 无法导入 copilot SDK。请运行: pip install github-copilot-sdk==1.0.2")
     sys.exit(1)
 
 async def fetch_real_models() -> List[Dict]:

--- a/plugins/pipes/github-copilot-sdk/test_sort.py
+++ b/plugins/pipes/github-copilot-sdk/test_sort.py
@@ -56,14 +56,15 @@ async def fetch_copilot(token: str) -> List[Dict]:
         return []
     try:
         from copilot import CopilotClient
-        from copilot.client import SubprocessConfig
     except ImportError as e:
         logger.error(f"Import error: {e}")
         return []
 
     try:
-        config = SubprocessConfig(github_token=token, use_logged_in_user=False)
-        client = CopilotClient(config=config, auto_start=True)
+        # copilot-sdk >= 1.0: SubprocessConfig removed; pass kwargs directly.
+        client = CopilotClient(
+            github_token=token, use_logged_in_user=False
+        )
         await client.start()
         raw = await client.list_models()
         logger.info(

--- a/plugins/pipes/github-copilot-sdk/tests/verify_persistence.py
+++ b/plugins/pipes/github-copilot-sdk/tests/verify_persistence.py
@@ -22,14 +22,16 @@ async def main():
     # Ensure it exists
     os.makedirs(config_dir, exist_ok=True)
 
-    client = CopilotClient({"config_dir": config_dir})
+    # copilot-sdk >= 1.0: CopilotClient takes kwargs directly; the config
+    # directory is expressed via base_directory (sets COPILOT_HOME).
+    client = CopilotClient(base_directory=config_dir)
     await client.start()
 
     try:
         # 1. Create a session
         logger.info("Creating a persistent session...")
         session = await client.create_session(
-            {"on_permission_request": PermissionHandler.approve_all, "model": "gpt-4o"}
+            on_permission_request=PermissionHandler.approve_all, model="gpt-4o"
         )
         chat_id = session.session_id
         logger.info(f"Session ID: {chat_id}")

--- a/scripts/deploy_pipe.py
+++ b/scripts/deploy_pipe.py
@@ -79,7 +79,7 @@ def deploy_pipe() -> None:
                     "and manage_skills tool."
                 ),
                 "version": version,
-                "requirements": "github-copilot-sdk==0.1.25",
+                "requirements": "github-copilot-sdk==1.0.2",
             },
             "type": "pipe",
         },


### PR DESCRIPTION
修复 issue #79 中报告的 github-copilot-sdk 安装和导入错误。

## 问题
- github-copilot-sdk==0.2.2 在 PyPI 不存在
- 改为 0.2.3 后 cannot import name Mode from copilot.generated.rpc

## 修复
- 更新 SDK 版本依赖
- 修复 Mode 导入路径

Closes #79