### PR TITLE
fix: migrate to github-copilot-sdk 1.0.2 API (closes #79)

### DIFF
--- a/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
+++ b/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
@@ -5,8 +5,8 @@ author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
 openwebui_id: ce96f7b4-12fc-4ac3-9a01-875713e69359
 description: A powerful Agent SDK integration for OpenWebUI. It deeply bridges GitHub Copilot SDK with OpenWebUI's ecosystem, enabling the Agent to autonomously perform intent recognition, web search, and context compaction. It seamlessly reuses your existing Tools, MCP servers, OpenAPI servers, and Skills for a professional, full-featured experience.
-version: 0.13.2
-requirements: github-copilot-sdk==0.2.2
+version: 0.13.3
+requirements: github-copilot-sdk==1.0.2
 """
 
 import asyncio
@@ -34,8 +34,8 @@ from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Dict, List, Literal, Optional, Tuple, Union
 
 import aiohttp
-from copilot import CopilotClient, define_tool
-from copilot.generated.rpc import Mode, SessionModeSetParams
+from copilot import CopilotClient, StdioRuntimeConnection, define_tool
+from copilot.generated.rpc import ModeSetRequest, SessionMode
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field, create_model
 
@@ -7303,17 +7303,24 @@ class Pipe:
         chat_id: Optional[str] = None,
         token: Optional[str] = None,
     ):
-        """Build CopilotClient config from valves and request body."""
-        from copilot import SubprocessConfig
+        """Build CopilotClient config from valves and request body.
 
+        github-copilot-sdk 1.0.x removed ``SubprocessConfig``; the client now
+        accepts keyword arguments directly. ``cli_path`` is replaced by an
+        explicit ``StdioRuntimeConnection`` passed via ``connection``.
+        """
         cwd = self._get_workspace_dir(user_id=user_id, chat_id=chat_id)
         config_dir = self._get_copilot_config_dir()
 
-        client_config = {}
+        client_config = {
+            "working_directory": cwd,
+            "github_token": token,
+        }
+
         if os.environ.get("COPILOT_CLI_PATH"):
-            client_config["cli_path"] = os.environ["COPILOT_CLI_PATH"]
-        client_config["cwd"] = cwd
-        client_config["github_token"] = token
+            client_config["connection"] = StdioRuntimeConnection(
+                path=os.environ["COPILOT_CLI_PATH"]
+            )
 
         if self.valves.LOG_LEVEL:
             client_config["log_level"] = self.valves.LOG_LEVEL
@@ -7372,7 +7379,7 @@ class Pipe:
 
         client_config["env"] = agent_env
 
-        return SubprocessConfig(**client_config)
+        return client_config
 
     # ==================== Agent Team Helpers ====================
 
@@ -7807,7 +7814,7 @@ class Pipe:
         session_mode: str = "autopilot",
     ):
         """Build SessionConfig for Copilot SDK."""
-        from copilot.session import InfiniteSessionConfig, SessionConfig
+        from copilot.session import InfiniteSessionConfig
 
         infinite_session_config = None
         if self.valves.INFINITE_SESSION:
@@ -7848,7 +7855,7 @@ class Pipe:
             "streaming": is_streaming,
             "tools": custom_tools,
             "system_message": system_message_config,
-            "config_dir": self._get_copilot_config_dir(),
+            "config_directory": self._get_copilot_config_dir(),
             "infinite_sessions": infinite_session_config,
             "working_directory": resolved_cwd,
         }
@@ -8438,7 +8445,7 @@ class Pipe:
             client = self.__class__._shared_clients.get(token_hash)
             if client:
                 try:
-                    state = client.get_state()
+                    state = getattr(client, "_state", "disconnected")
                     if state == "connected":
                         return client
                     if state == "error":
@@ -8459,7 +8466,7 @@ class Pipe:
                 user_id=None, chat_id=None, token=token
             )
 
-            new_client = CopilotClient(client_config, auto_start=True)
+            new_client = CopilotClient(**client_config)
             await new_client.start()
             self.__class__._shared_clients[token_hash] = new_client
             return new_client
@@ -9193,7 +9200,7 @@ class Pipe:
         client_config = self._build_client_config(
             user_id=user_id, chat_id=chat_id, token=effective_token
         )
-        client = CopilotClient(client_config)
+        client = CopilotClient(**client_config)
         should_stop_client = True
         try:
             await client.start()
@@ -9298,7 +9305,7 @@ class Pipe:
                         "model": real_model_id,
                         "streaming": is_streaming,
                         "tools": custom_tools,
-                        "config_dir": self._get_copilot_config_dir(),
+                        "config_directory": self._get_copilot_config_dir(),
                     }
 
                     permission_request_handler = getattr(
@@ -9416,9 +9423,9 @@ class Pipe:
                     # The system prompt already carries the active-mode directive, so this
                     # is an additional SDK-level hint.  A 5-second timeout prevents hangs.
                     try:
-                        mode_enum = Mode(effective_session_mode)
+                        mode_enum = SessionMode(effective_session_mode)
                         await asyncio.wait_for(
-                            session.rpc.mode.set(SessionModeSetParams(mode=mode_enum)),
+                            session.rpc.mode.set(ModeSetRequest(mode=mode_enum)),
                             timeout=5.0,
                         )
                         logger.info(
@@ -9500,9 +9507,9 @@ class Pipe:
                 # The system prompt already carries the active-mode directive, so this
                 # is an additional SDK-level hint.  A 5-second timeout prevents hangs.
                 try:
-                    mode_enum = Mode(effective_session_mode)
+                    mode_enum = SessionMode(effective_session_mode)
                     await asyncio.wait_for(
-                        session.rpc.mode.set(SessionModeSetParams(mode=mode_enum)),
+                        session.rpc.mode.set(ModeSetRequest(mode=mode_enum)),
                         timeout=5.0,
                     )
                     logger.info(

--- a/plugins/pipes/github-copilot-sdk/scripts/sync_to_workspace.py
+++ b/plugins/pipes/github-copilot-sdk/scripts/sync_to_workspace.py
@@ -16,7 +16,7 @@ except ImportError:
 try:
     from copilot import CopilotClient
 except ImportError:
-    print("❌ 错误: 无法导入 copilot SDK。请运行: pip install github-copilot-sdk==0.1.23")
+    print("❌ 错误: 无法导入 copilot SDK。请运行: pip install github-copilot-sdk==1.0.2")
     sys.exit(1)
 
 async def fetch_real_models() -> List[Dict]:


### PR DESCRIPTION
基于 github-copilot-sdk 1.0.2 真实 API 进行正确迁移升级。

## 迁移内容
- SubprocessConfig 已移除，改用 CopilotClient 关键字参数 + StdioRuntimeConnection
- SessionConfig 已移除，session_params 直接传给 create_session
- config_dir → config_directory
- Mode → SessionMode, SessionModeSetParams → ModeSetRequest
- client.get_state() → getattr(client, "_state", "disconnected")
- CopilotClient(client_config, auto_start=True) → CopilotClient(**client_config) + await start()

## 验证
通过本地 pip install github-copilot-sdk==1.0.2 验证所有 API 变更。

Closes #79