### PR TITLE
fix: migrate to github-copilot-sdk 1.0.2 API (closes #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A collection of enhancements, plugins, and prompts for [open-webui](https://gith
 
 ## 🌟 Star Features
 
-### 1. [GitHub Copilot Official SDK Pipe](https://openwebui.com/posts/github_copilot_official_sdk_pipe_ce96f7b4) ![v0.13.2](https://img.shields.io/badge/v0.13.2-blue?style=flat-square) ![active-dev](https://img.shields.io/badge/active--dev-orange?style=flat-square) ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_post_aef940e01073e811a311c3a443d9c149_dl.json&style=flat-square) ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_post_aef940e01073e811a311c3a443d9c149_vw.json&style=flat-square) ![updated](https://img.shields.io/badge/2026--05--11-gray?style=flat)
+### 1. [GitHub Copilot Official SDK Pipe](https://openwebui.com/posts/github_copilot_official_sdk_pipe_ce96f7b4) ![v0.13.3](https://img.shields.io/badge/v0.13.3-blue?style=flat-square) ![active-dev](https://img.shields.io/badge/active--dev-orange?style=flat-square) ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_post_aef940e01073e811a311c3a443d9c149_dl.json&style=flat-square) ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_post_aef940e01073e811a311c3a443d9c149_vw.json&style=flat-square) ![updated](https://img.shields.io/badge/2026--06--21-gray?style=flat)
 
 **The ultimate autonomous Agent integration for OpenWebUI.** Deeply bridging GitHub Copilot SDK with your OpenWebUI ecosystem. It enables the Agent to autonomously perform **intent recognition**, **web search**, and **context compaction** while reusing your existing tools, skills, and configurations for a professional, full-featured experience.
 
@@ -134,7 +134,7 @@ Located in the `plugins/` directory, containing Python-based enhancements:
 
 ### Pipes
 
-- **GitHub Copilot SDK** (`github-copilot-sdk`): Official GitHub Copilot SDK integration (v0.13.2). Supports OpenWebUI 0.9.x compatibility, BYOK model priority, dynamic models (GPT-4o, Claude 3.7, o1), multi-turn conversation, and high-performance process pooling.
+- **GitHub Copilot SDK** (`github-copilot-sdk`): Official GitHub Copilot SDK integration (v0.13.3). Supports OpenWebUI 0.9.x compatibility, BYOK model priority, dynamic models (GPT-4o, Claude 3.7, o1), multi-turn conversation, and high-performance process pooling.
 
 ### Pipelines
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -131,7 +131,7 @@ OpenWebUI 增强功能集合。包含个人开发与收集的插件、提示词�
 
 ### Pipes (模型管道)
 
-- **GitHub Copilot SDK** (`github-copilot-sdk`): 深度集成 GitHub Copilot SDK 的强大 Agent (v0.13.2)。支持 OpenWebUI 0.9.x 全面兼容、BYOK 模型优先级、纯 BYOK 模式、智能意图识别、自主网页搜索与上下文压缩。
+- **GitHub Copilot SDK** (`github-copilot-sdk`): 深度集成 GitHub Copilot SDK 的强大 Agent (v0.13.3)。支持 OpenWebUI 0.9.x 全面兼容、BYOK 模型优先级、纯 BYOK 模式、智能意图识别、自主网页搜索与上下文压缩。
 
 ### Pipelines (工作流管道)
 

--- a/docs/plugins/pipes/github-copilot-sdk.md
+++ b/docs/plugins/pipes/github-copilot-sdk.md
@@ -1,6 +1,6 @@
 # GitHub Copilot SDK Pipe for OpenWebUI
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v0.13.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v0.13.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -39,12 +39,12 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
 
-## ✨ v0.13.1: OpenWebUI 0.9.x Compatibility
+## ✨ v0.13.3: SDK 1.0.2 API Migration
 
-- **🔌 OpenWebUI 0.9.x Dual Compatibility** (Critical): All OpenWebUI model/config/tool APIs (`Files.get_file_by_id`, `Files.insert_new_file`, `Users.get_user_by_id`, `Tools.get_tools_by_user_id`, `Tools.get_tool_by_id`, `Models.get_model_by_id`, `get_config`, `get_all_models`, `get_openwebui_tools`, `get_builtin_tools`, `search_models`) now transparently support both the sync interface (pre-0.9) and the new async interface (0.9.x). No version branching required; the plugin auto-detects and adapts.
-- **🚀 Internal Methods Promoted to Async**: `_read_tool_server_connections`, `_build_openwebui_request`, and `_parse_mcp_servers` are now `async def`, eliminating the thread-offload pattern that would have broken under 0.9.x async model methods.
-- **🛡️ Sync-Safe Valve Options**: `Valves` and `UserValves` option providers (sync classmethods) now use a compatibility wrapper so `search_models` calls remain safe in both sync and async contexts.
-- **🐛 File Publish Path Fixed**: `publish_file_from_workspace` now uses a typed compatibility layer instead of raw `asyncio.to_thread`, resolving a silent crash when `Files` methods became coroutines in 0.9.x.
+- **📦 github-copilot-sdk 1.0.2**: Migrated to the stable 1.0.2 release. Removed deprecated `SubprocessConfig` and `SessionConfig` wrappers — connection and session options are now passed as plain dicts directly to `CopilotClient` and `create_session`/`resume_session`.
+- **🔄 API Renames**: `Mode` → `SessionMode`, `SessionModeSetParams` → `ModeSetRequest`, `get_messages()` → `get_events()`, `destroy()` → `disconnect()`, `config_dir` → `config_directory`.
+- **🔌 Client Lifecycle**: `CopilotClient` no longer accepts `auto_start`; call `await client.start()` explicitly after construction.
+- **📊 State Access**: Replaced `client.get_state()` with direct `client._state` attribute access (returns `Literal["disconnected", "connecting", "connected", "error"]`).
 
 ---
 

--- a/docs/plugins/pipes/github-copilot-sdk.zh.md
+++ b/docs/plugins/pipes/github-copilot-sdk.zh.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Official SDK Pipe
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.13.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.13.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -40,12 +40,12 @@
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
 
-## ✨ v0.13.1：OpenWebUI 0.9.x 兼容
+## ✨ v0.13.3：SDK 1.0.2 API 迁移
 
-- **🔌 OpenWebUI 0.9.x 双兼容**（关键）：所有 OpenWebUI 模型/配置/工具 API（`Files.get_file_by_id`、`Files.insert_new_file`、`Users.get_user_by_id`、`Tools.get_tools_by_user_id`、`Tools.get_tool_by_id`、`Models.get_model_by_id`、`get_config`、`get_all_models`、`get_openwebui_tools`、`get_builtin_tools`、`search_models`）现已透明支持同步接口（0.9 以下）和异步接口（0.9.x），无需手动版本分支判断，插件自动适配。
-- **🚀 内部方法升级为 async**：`_read_tool_server_connections`、`_build_openwebui_request` 和 `_parse_mcp_servers` 已升级为 `async def`，消除了在 0.9.x 异步模型方法下会崩溃的线程托底模式。
-- **🛡️ 同步安全的选项提供器**：`Valves` 和 `UserValves` 选项提供器（同步 classmethod）现使用兼容封装，使 `search_models` 调用在同步和异步上下文中均安全。
-- **🐛 文件发布路径修复**：`publish_file_from_workspace` 现使用类型安全的兼容层替代原始 `asyncio.to_thread`，解决了 Files 方法在 0.9.x 变为协程后的静默崩溃问题。
+- **📦 github-copilot-sdk 1.0.2**：迁移至稳定的 1.0.2 版本。移除了已弃用的 `SubprocessConfig` 和 `SessionConfig` 包装器——连接和会话选项现在以普通字典形式直接传递给 `CopilotClient` 和 `create_session`/`resume_session`。
+- **🔄 API 重命名**：`Mode` → `SessionMode`、`SessionModeSetParams` → `ModeSetRequest`、`get_messages()` → `get_events()`、`destroy()` → `disconnect()`、`config_dir` → `config_directory`。
+- **🔌 客户端生命周期**：`CopilotClient` 不再接受 `auto_start` 参数；构造后需显式调用 `await client.start()`。
+- **📊 状态访问**：用直接属性 `client._state` 替代 `client.get_state()`（返回 `Literal["disconnected", "connecting", "connected", "error"]`）。
 
 ---
 

--- a/docs/plugins/pipes/index.md
+++ b/docs/plugins/pipes/index.md
@@ -15,7 +15,7 @@ Pipes allow you to:
 
 ## Available Pipe Plugins
 
-- [GitHub Copilot SDK](github-copilot-sdk.md) (v0.13.2) - Official GitHub Copilot SDK integration. Features **Workspace Isolation**, **Zero-config OpenWebUI Tool Bridge**, **BYOK** support, and **dynamic MCP discovery**. **v0.13.2: BYOK model priority — when both BYOK_MODELS and BYOK_BASE_URL are set, the plugin now prioritizes the user-configured model list directly**. [View Deep Dive](github-copilot-sdk-deep-dive.md) | [**View Advanced Tutorial**](github-copilot-sdk-tutorial.md) | [**View Detailed Usage Guide**](github-copilot-sdk-usage-guide.md).
+- [GitHub Copilot SDK](github-copilot-sdk.md) (v0.13.3) - Official GitHub Copilot SDK integration. Features **Workspace Isolation**, **Zero-config OpenWebUI Tool Bridge**, **BYOK** support, and **dynamic MCP discovery**. **v0.13.3: Migrated to github-copilot-sdk 1.0.2 stable API — removed deprecated SubprocessConfig/SessionConfig wrappers, adopted renamed types (SessionMode, ModeSetRequest) and methods (get_events, disconnect)**. [View Deep Dive](github-copilot-sdk-deep-dive.md) | [**View Advanced Tutorial**](github-copilot-sdk-tutorial.md) | [**View Detailed Usage Guide**](github-copilot-sdk-usage-guide.md).
 - **[Case Study: GitHub 100 Star Growth Analysis](star-prediction-example.md)** - Learn how to use the GitHub Copilot SDK Pipe with Minimax 2.1 to automatically analyze CSV data and generate project growth reports.
 - **[Case Study: High-Quality Video to GIF Conversion](video-processing-example.md)** - See how the model uses system-level FFmpeg to accelerate, scale, and optimize colors for screen recordings.
 

--- a/docs/plugins/pipes/index.zh.md
+++ b/docs/plugins/pipes/index.zh.md
@@ -15,7 +15,7 @@ Pipes 可以用于：
 
 ## 可用的 Pipe 插件
 
-- [GitHub Copilot SDK](github-copilot-sdk.zh.md) (v0.13.2) - GitHub Copilot SDK 官方集成。具备**工作区安全隔离**、**零配置工具桥接**与**BYOK (自带 Key) 支持**。**v0.13.2 更新：BYOK 模型优先级——当同时配置 BYOK_MODELS 和 BYOK_BASE_URL 时，插件现在优先使用用户显式配置的模型列表**。[[查看深度架构解析](github-copilot-sdk-deep-dive.zh.md) | [**查看 进阶 实战教程**](github-copilot-sdk-tutorial.zh.md) | [**查看详细使用手册**](github-copilot-sdk-usage-guide.zh.md)。
+- [GitHub Copilot SDK](github-copilot-sdk.zh.md) (v0.13.3) - GitHub Copilot SDK 官方集成。具备**工作区安全隔离**、**零配置工具桥接**与**BYOK (自带 Key) 支持**。**v0.13.3 更新：迁移至 github-copilot-sdk 1.0.2 稳定 API——移除已弃用的 SubprocessConfig/SessionConfig 包装器，采用重命名的类型（SessionMode、ModeSetRequest）和方法（get_events、disconnect）**。[[查看深度架构解析](github-copilot-sdk-deep-dive.zh.md) | [**查看 进阶 实战教程**](github-copilot-sdk-tutorial.zh.md) | [**查看详细使用手册**](github-copilot-sdk-usage-guide.zh.md)。
 - **[实战案例：GitHub 100 Star 增长预测](star-prediction-example.zh.md)** - 展示如何使用 GitHub Copilot SDK Pipe 结合 Minimax 2.1 模型，自动编写脚本分析 CSV 数据并生成详细的项目增长报告。
 - **[实战案例：视频高质量 GIF 转换与加速](video-processing-example.zh.md)** - 演示模型如何通过底层 FFmpeg 工具对录屏进行加速、缩放及双阶段色彩优化处理。
 

--- a/plugins/pipes/github-copilot-sdk/README.md
+++ b/plugins/pipes/github-copilot-sdk/README.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Agent Pipe for OpenWebUI
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v0.13.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v0.13.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -33,12 +33,12 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
 
-## ✨ v0.13.1: OpenWebUI 0.9.x Compatibility
+## ✨ v0.13.3: SDK 1.0.2 API Migration
 
-- **🔌 OpenWebUI 0.9.x Dual Compatibility** (Critical): All OpenWebUI model/config/tool APIs (`Files.get_file_by_id`, `Files.insert_new_file`, `Users.get_user_by_id`, `Tools.get_tools_by_user_id`, `Tools.get_tool_by_id`, `Models.get_model_by_id`, `get_config`, `get_all_models`, `get_openwebui_tools`, `get_builtin_tools`, `search_models`) now transparently support both the sync interface (pre-0.9) and the new async interface (0.9.x). No version branching required; the plugin auto-detects and adapts.
-- **🚀 Internal Methods Promoted to Async**: `_read_tool_server_connections`, `_build_openwebui_request`, and `_parse_mcp_servers` are now `async def`, eliminating the thread-offload pattern that would have broken under 0.9.x async model methods.
-- **🛡️ Sync-Safe Valve Options**: `Valves` and `UserValves` option providers (sync classmethods) now use a compatibility wrapper so `search_models` calls remain safe in both sync and async contexts.
-- **🐛 File Publish Path Fixed**: `publish_file_from_workspace` now uses a typed compatibility layer instead of raw `asyncio.to_thread`, resolving a silent crash when `Files` methods became coroutines in 0.9.x.
+- **📦 github-copilot-sdk 1.0.2**: Migrated to the stable 1.0.2 release. Removed deprecated `SubprocessConfig` and `SessionConfig` wrappers — connection and session options are now passed as plain dicts directly to `CopilotClient` and `create_session`/`resume_session`.
+- **🔄 API Renames**: `Mode` → `SessionMode`, `SessionModeSetParams` → `ModeSetRequest`, `get_messages()` → `get_events()`, `destroy()` → `disconnect()`, `config_dir` → `config_directory`.
+- **🔌 Client Lifecycle**: `CopilotClient` no longer accepts `auto_start`; call `await client.start()` explicitly after construction.
+- **📊 State Access**: Replaced `client.get_state()` with direct `client._state` attribute access (returns `Literal["disconnected", "connecting", "connected", "error"]`).
 
 > [!IMPORTANT]
 > **If the plugin shows errors after an update, restart your OpenWebUI server.** The plugin is cached in memory and old bytecode may cause import errors. Restarting clears the cache and loads the fresh version.

--- a/plugins/pipes/github-copilot-sdk/README_CN.md
+++ b/plugins/pipes/github-copilot-sdk/README_CN.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Agent SDK Pipe
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.13.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.13.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -31,12 +31,12 @@
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
 
-## ✨ v0.13.1：OpenWebUI 0.9.x 兼容
+## ✨ v0.13.3：SDK 1.0.2 API 迁移
 
-- **🔌 OpenWebUI 0.9.x 双兼容**（关键）：所有 OpenWebUI 模型/配置/工具 API（`Files.get_file_by_id`、`Files.insert_new_file`、`Users.get_user_by_id`、`Tools.get_tools_by_user_id`、`Tools.get_tool_by_id`、`Models.get_model_by_id`、`get_config`、`get_all_models`、`get_openwebui_tools`、`get_builtin_tools`、`search_models`）现已透明支持同步接口（0.9 以下）和异步接口（0.9.x），无需手动版本分支判断，插件自动适配。
-- **🚀 内部方法升级为 async**：`_read_tool_server_connections`、`_build_openwebui_request` 和 `_parse_mcp_servers` 已升级为 `async def`，消除了在 0.9.x 异步模型方法下会崩溃的线程托底模式。
-- **🛡️ 同步安全的选项提供器**：`Valves` 和 `UserValves` 选项提供器（同步 classmethod）现使用兼容封装，使 `search_models` 调用在同步和异步上下文中均安全。
-- **🐛 文件发布路径修复**：`publish_file_from_workspace` 现使用类型安全的兼容层替代原始 `asyncio.to_thread`，解决了 Files 方法在 0.9.x 变为协程后的静默崩溃问题。
+- **📦 github-copilot-sdk 1.0.2**：迁移至稳定的 1.0.2 版本。移除了已弃用的 `SubprocessConfig` 和 `SessionConfig` 包装器——连接和会话选项现在以普通字典形式直接传递给 `CopilotClient` 和 `create_session`/`resume_session`。
+- **🔄 API 重命名**：`Mode` → `SessionMode`、`SessionModeSetParams` → `ModeSetRequest`、`get_messages()` → `get_events()`、`destroy()` → `disconnect()`、`config_dir` → `config_directory`。
+- **🔌 客户端生命周期**：`CopilotClient` 不再接受 `auto_start` 参数；构造后需显式调用 `await client.start()`。
+- **📊 状态访问**：用直接属性 `client._state` 替代 `client.get_state()`（返回 `Literal["disconnected", "connecting", "connected", "error"]`）。
 
 > [!IMPORTANT]
 > **如果插件在更新后报错，请重启 OpenWebUI 服务器。** 插件代码会被缓存在内存中，旧字节码可能导致 import 错误，重启可以清除缓存并加载新版本。

--- a/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
+++ b/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
@@ -6,7 +6,7 @@ funding_url: https://github.com/open-webui
 openwebui_id: ce96f7b4-12fc-4ac3-9a01-875713e69359
 description: A powerful Agent SDK integration for OpenWebUI. It deeply bridges GitHub Copilot SDK with OpenWebUI's ecosystem, enabling the Agent to autonomously perform intent recognition, web search, and context compaction. It seamlessly reuses your existing Tools, MCP servers, OpenAPI servers, and Skills for a professional, full-featured experience.
 version: 0.13.2
-requirements: github-copilot-sdk==0.2.2
+requirements: github-copilot-sdk==1.0.2
 """
 
 import asyncio
@@ -35,7 +35,7 @@ from typing import Any, AsyncGenerator, Dict, List, Literal, Optional, Tuple, Un
 
 import aiohttp
 from copilot import CopilotClient, define_tool
-from copilot.generated.rpc import Mode, SessionModeSetParams
+from copilot.generated.rpc import SessionMode, ModeSetRequest
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field, create_model
 
@@ -7303,16 +7303,24 @@ class Pipe:
         chat_id: Optional[str] = None,
         token: Optional[str] = None,
     ):
-        """Build CopilotClient config from valves and request body."""
-        from copilot import SubprocessConfig
+        """Build CopilotClient config from valves and request body.
+
+        github-copilot-sdk >= 1.0: CopilotClient accepts keyword arguments
+        directly (no SubprocessConfig). cli_path is replaced by
+        connection=StdioRuntimeConnection(path=...); cwd is renamed to
+        working_directory.
+        """
+        from copilot import StdioRuntimeConnection
 
         cwd = self._get_workspace_dir(user_id=user_id, chat_id=chat_id)
         config_dir = self._get_copilot_config_dir()
 
-        client_config = {}
+        client_config: Dict[str, Any] = {}
         if os.environ.get("COPILOT_CLI_PATH"):
-            client_config["cli_path"] = os.environ["COPILOT_CLI_PATH"]
-        client_config["cwd"] = cwd
+            client_config["connection"] = StdioRuntimeConnection(
+                path=os.environ["COPILOT_CLI_PATH"]
+            )
+        client_config["working_directory"] = cwd
         client_config["github_token"] = token
 
         if self.valves.LOG_LEVEL:
@@ -7372,7 +7380,7 @@ class Pipe:
 
         client_config["env"] = agent_env
 
-        return SubprocessConfig(**client_config)
+        return client_config
 
     # ==================== Agent Team Helpers ====================
 
@@ -7807,7 +7815,7 @@ class Pipe:
         session_mode: str = "autopilot",
     ):
         """Build SessionConfig for Copilot SDK."""
-        from copilot.session import InfiniteSessionConfig, SessionConfig
+        from copilot.session import InfiniteSessionConfig
 
         infinite_session_config = None
         if self.valves.INFINITE_SESSION:
@@ -7848,7 +7856,7 @@ class Pipe:
             "streaming": is_streaming,
             "tools": custom_tools,
             "system_message": system_message_config,
-            "config_dir": self._get_copilot_config_dir(),
+            "config_directory": self._get_copilot_config_dir(),
             "infinite_sessions": infinite_session_config,
             "working_directory": resolved_cwd,
         }
@@ -8438,7 +8446,10 @@ class Pipe:
             client = self.__class__._shared_clients.get(token_hash)
             if client:
                 try:
-                    state = client.get_state()
+                    # copilot-sdk >= 1.0 removed the public get_state(); the
+                    # equivalent connection state lives on the private _state
+                    # attribute ("disconnected"|"connecting"|"connected"|"error").
+                    state = getattr(client, "_state", "disconnected")
                     if state == "connected":
                         return client
                     if state == "error":
@@ -8454,12 +8465,14 @@ class Pipe:
             if not self.__class__._env_setup_done:
                 self._setup_env(token=token)
 
-            # Build configuration and start persistent client
+            # Build configuration and start persistent client.
+            # copilot-sdk >= 1.0: CopilotClient takes keyword args (no
+            # positional config, no auto_start flag); call start() manually.
             client_config = self._build_client_config(
                 user_id=None, chat_id=None, token=token
             )
 
-            new_client = CopilotClient(client_config, auto_start=True)
+            new_client = CopilotClient(**client_config)
             await new_client.start()
             self.__class__._shared_clients[token_hash] = new_client
             return new_client
@@ -9193,7 +9206,7 @@ class Pipe:
         client_config = self._build_client_config(
             user_id=user_id, chat_id=chat_id, token=effective_token
         )
-        client = CopilotClient(client_config)
+        client = CopilotClient(**client_config)
         should_stop_client = True
         try:
             await client.start()
@@ -9293,12 +9306,12 @@ class Pipe:
                     resolved_cwd = self._get_workspace_dir(
                         user_id=user_id, chat_id=chat_id
                     )
-                    # Prepare resume config (Requires github-copilot-sdk >= 0.1.23)
+                    # Prepare resume config (Requires github-copilot-sdk >= 1.0.2)
                     resume_params = {
                         "model": real_model_id,
                         "streaming": is_streaming,
                         "tools": custom_tools,
-                        "config_dir": self._get_copilot_config_dir(),
+                        "config_directory": self._get_copilot_config_dir(),
                     }
 
                     permission_request_handler = getattr(
@@ -9416,9 +9429,9 @@ class Pipe:
                     # The system prompt already carries the active-mode directive, so this
                     # is an additional SDK-level hint.  A 5-second timeout prevents hangs.
                     try:
-                        mode_enum = Mode(effective_session_mode)
+                        mode_enum = SessionMode(effective_session_mode)
                         await asyncio.wait_for(
-                            session.rpc.mode.set(SessionModeSetParams(mode=mode_enum)),
+                            session.rpc.mode.set(ModeSetRequest(mode=mode_enum)),
                             timeout=5.0,
                         )
                         logger.info(
@@ -9500,9 +9513,9 @@ class Pipe:
                 # The system prompt already carries the active-mode directive, so this
                 # is an additional SDK-level hint.  A 5-second timeout prevents hangs.
                 try:
-                    mode_enum = Mode(effective_session_mode)
+                    mode_enum = SessionMode(effective_session_mode)
                     await asyncio.wait_for(
-                        session.rpc.mode.set(SessionModeSetParams(mode=mode_enum)),
+                        session.rpc.mode.set(ModeSetRequest(mode=mode_enum)),
                         timeout=5.0,
                     )
                     logger.info(

--- a/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
+++ b/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
@@ -7954,7 +7954,10 @@ class Pipe:
         previous interrupted request, which may cause unrelated extra model turns.
         """
         try:
-            history = await session.get_messages()
+            # copilot-sdk >= 1.0: get_messages() removed; use get_events()
+            # which returns list[SessionEvent] with the same .type attribute
+            # (user.message, assistant.turn_start, assistant.turn_end, etc.)
+            history = await session.get_events()
         except Exception as e:
             await self._emit_debug_log(
                 f"Failed to inspect resumed session history: {e}",
@@ -9621,10 +9624,11 @@ class Pipe:
                         else "Empty response."
                     )
                 finally:
-                    # Cleanup: destroy session if no chat_id (temporary session)
+                    # Cleanup: disconnect session if no chat_id (temporary session)
+                    # copilot-sdk >= 1.0: destroy() removed; use disconnect()
                     if not chat_id:
                         try:
-                            await session.destroy()
+                            await session.disconnect()
                         except Exception as cleanup_error:
                             await self._emit_debug_log(
                                 f"Session cleanup warning: {cleanup_error}",

--- a/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
+++ b/plugins/pipes/github-copilot-sdk/github_copilot_sdk.py
@@ -5,7 +5,7 @@ author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
 openwebui_id: ce96f7b4-12fc-4ac3-9a01-875713e69359
 description: A powerful Agent SDK integration for OpenWebUI. It deeply bridges GitHub Copilot SDK with OpenWebUI's ecosystem, enabling the Agent to autonomously perform intent recognition, web search, and context compaction. It seamlessly reuses your existing Tools, MCP servers, OpenAPI servers, and Skills for a professional, full-featured experience.
-version: 0.13.2
+version: 0.13.3
 requirements: github-copilot-sdk==1.0.2
 """
 

--- a/plugins/pipes/github-copilot-sdk/scripts/sync_to_workspace.py
+++ b/plugins/pipes/github-copilot-sdk/scripts/sync_to_workspace.py
@@ -16,7 +16,7 @@ except ImportError:
 try:
     from copilot import CopilotClient
 except ImportError:
-    print("❌ 错误: 无法导入 copilot SDK。请运行: pip install github-copilot-sdk==0.1.23")
+    print("❌ 错误: 无法导入 copilot SDK。请运行: pip install github-copilot-sdk==1.0.2")
     sys.exit(1)
 
 async def fetch_real_models() -> List[Dict]:

--- a/plugins/pipes/github-copilot-sdk/v0.13.3.md
+++ b/plugins/pipes/github-copilot-sdk/v0.13.3.md
@@ -1,0 +1,54 @@
+# v0.13.3 Release Notes
+
+## Overview
+
+This patch release migrates the plugin to the stable `github-copilot-sdk==1.0.2` API, removing all deprecated wrappers and adopting the renamed types and methods.
+
+## Breaking Changes
+
+- **`requirements` updated**: `github-copilot-sdk==0.2.2` → `github-copilot-sdk==1.0.2`. Users must update their environment.
+- **`CopilotClient` lifecycle**: The `auto_start` parameter is removed. Call `await client.start()` explicitly after construction.
+- **`config_dir` → `config_directory`**: Both `create_session` and `resume_session` now use `config_directory` as the keyword argument name.
+
+## API Migrations
+
+### Removed Wrappers
+
+| Old (0.2.x) | New (1.0.2) |
+|-------------|-------------|
+| `SubprocessConfig(path=..., args=...)` | Plain dict `{"path": ..., "args": ...}` passed to `StdioRuntimeConnection` |
+| `SessionConfig(...)` | Plain dict passed to `create_session`/`resume_session` |
+
+### Renamed Types
+
+| Old (0.2.x) | New (1.0.2) |
+|-------------|-------------|
+| `Mode` | `SessionMode` |
+| `SessionModeSetParams` | `ModeSetRequest` |
+
+### Renamed Methods
+
+| Old (0.2.x) | New (1.0.2) |
+|-------------|-------------|
+| `session.get_messages()` | `session.get_events()` |
+| `session.destroy()` | `session.disconnect()` |
+| `client.get_state()` | `client._state` (attribute, returns `Literal["disconnected", "connecting", "connected", "error"]`) |
+
+## Verification
+
+All API changes were verified against the locally installed `github-copilot-sdk==1.0.2` source:
+
+- [x] `SubprocessConfig` and `SessionConfig` confirmed removed (`ImportError`)
+- [x] `StdioRuntimeConnection` importable from `copilot` with signature `(path: str | None, args: Sequence[str])`
+- [x] `SessionMode` members: `INTERACTIVE`, `PLAN`, `AUTOPILOT`
+- [x] `ModeSetRequest` fields verified
+- [x] `CopilotClient.__init__` has no `auto_start` parameter
+- [x] `client._state` is `Literal` type (not `Enum`), direct string comparison is correct
+- [x] `session.get_events()` and `session.disconnect()` exist; `get_messages()` and `destroy()` removed
+- [x] `create_session` and `resume_session` use `config_directory` (not `config_dir`)
+
+## Related
+
+- GitHub Issue: #79 (SDK 1.0.2 migration)
+- GitHub PR: #90
+- Companion Plugins: [GitHub Copilot SDK Files Filter](https://openwebui.com/posts/403a62ee-a596-45e7-be65-fab9cc249dd6)

--- a/plugins/pipes/github-copilot-sdk/v0.13.3_CN.md
+++ b/plugins/pipes/github-copilot-sdk/v0.13.3_CN.md
@@ -1,0 +1,54 @@
+# v0.13.3 版本发布说明
+
+## 概述
+
+本补丁版本将插件迁移至稳定的 `github-copilot-sdk==1.0.2` API，移除所有已弃用的包装器，采用重命名后的类型和方法。
+
+## 破坏性改动
+
+- **`requirements` 更新**：`github-copilot-sdk==0.2.2` → `github-copilot-sdk==1.0.2`。用户需要更新运行环境。
+- **`CopilotClient` 生命周期**：移除了 `auto_start` 参数。构造后需显式调用 `await client.start()`。
+- **`config_dir` → `config_directory`**：`create_session` 和 `resume_session` 现在使用 `config_directory` 作为关键字参数名。
+
+## API 迁移
+
+### 移除的包装器
+
+| 旧 (0.2.x) | 新 (1.0.2) |
+|-------------|-------------|
+| `SubprocessConfig(path=..., args=...)` | 普通字典 `{"path": ..., "args": ...}` 传给 `StdioRuntimeConnection` |
+| `SessionConfig(...)` | 普通字典传给 `create_session`/`resume_session` |
+
+### 重命名的类型
+
+| 旧 (0.2.x) | 新 (1.0.2) |
+|-------------|-------------|
+| `Mode` | `SessionMode` |
+| `SessionModeSetParams` | `ModeSetRequest` |
+
+### 重命名的方法
+
+| 旧 (0.2.x) | 新 (1.0.2) |
+|-------------|-------------|
+| `session.get_messages()` | `session.get_events()` |
+| `session.destroy()` | `session.disconnect()` |
+| `client.get_state()` | `client._state`（属性，返回 `Literal["disconnected", "connecting", "connected", "error"]`） |
+
+## 验证
+
+所有 API 变更均已通过本地安装的 `github-copilot-sdk==1.0.2` 源码验证：
+
+- [x] `SubprocessConfig` 和 `SessionConfig` 确认已移除（`ImportError`）
+- [x] `StdioRuntimeConnection` 可从 `copilot` 导入，签名为 `(path: str | None, args: Sequence[str])`
+- [x] `SessionMode` 成员：`INTERACTIVE`、`PLAN`、`AUTOPILOT`
+- [x] `ModeSetRequest` 字段已验证
+- [x] `CopilotClient.__init__` 无 `auto_start` 参数
+- [x] `client._state` 是 `Literal` 类型（非 `Enum`），直接字符串比较正确
+- [x] `session.get_events()` 和 `session.disconnect()` 存在；`get_messages()` 和 `destroy()` 已移除
+- [x] `create_session` 和 `resume_session` 使用 `config_directory`（非 `config_dir`）
+
+## 相关信息
+
+- GitHub Issue：#79（SDK 1.0.2 迁移）
+- GitHub PR：#90
+- 配套插件：[GitHub Copilot SDK 文件过滤器](https://openwebui.com/posts/403a62ee-a596-45e7-be65-fab9cc249dd6)

--- a/scripts/deploy_pipe.py
+++ b/scripts/deploy_pipe.py
@@ -79,7 +79,7 @@ def deploy_pipe() -> None:
                     "and manage_skills tool."
                 ),
                 "version": version,
-                "requirements": "github-copilot-sdk==0.1.25",
+                "requirements": "github-copilot-sdk==1.0.2",
             },
             "type": "pipe",
         },


### PR DESCRIPTION
fix: migrate to github-copilot-sdk 1.0.2 API (closes #79)

基于 github-copilot-sdk 1.0.2 真实源码（本地 pip install 验证）进行正确迁移，修复 issue #79 中报告的版本与导入错误。

## 问题
issue #79 报告：
- `github-copilot-sdk==0.2.2` 在 PyPI 不存在
- 改为 `0.2.3` 后 `cannot import name Mode from copilot.generated.rpc`

## 根因
之前的 PR #88 基于错误的 API 推测进行迁移，未查看真实源码。本次基于本地 `pip install github-copilot-sdk==1.0.2` 验证的真实 API 重新迁移。

## 迁移内容（全部基于真实 API 验证）

### 1. SubprocessConfig 已移除
`_build_client_config` 直接返回 dict，不再包装为 `SubprocessConfig`：
- `cli_path` → `connection=StdioRuntimeConnection(path=...)`
- `cwd` → `working_directory`

### 2. SessionConfig 已移除
`session_params` 直接作为 dict 传给 `create_session(**session_params)`，不再需要 `SessionConfig` 包装。

### 3. 参数重命名
`config_dir` → `config_directory`（在 `create_session` 和 `resume_session` 中，已通过 `inspect.signature` 验证）

### 4. Mode 相关
```python
# 旧:
from copilot.generated.rpc import Mode, SessionModeSetParams
mode_enum = Mode(effective_session_mode)
session.rpc.mode.set(SessionModeSetParams(mode=mode_enum))

# 新:
from copilot.generated.rpc import SessionMode, ModeSetRequest
mode_enum = SessionMode(effective_session_mode)
session.rpc.mode.set(ModeSetRequest(mode=mode_enum))
```
`SessionMode` 枚举成员: `INTERACTIVE='interactive'`, `PLAN='plan'`, `AUTOPILOT='autopilot'`

### 5. get_state() 已移除
```python
# 旧: state = client.get_state()
# 新: state = getattr(client, "_state", "disconnected")
```
1.0 移除了公开的 `get_state()`，连接状态移至私有 `_state` 属性（值: `disconnected`/`connecting`/`connected`/`error`）。

### 6. CopilotClient 创建
```python
# 旧: new_client = CopilotClient(client_config, auto_start=True)
# 新: new_client = CopilotClient(**client_config); await new_client.start()
```
`auto_start` 参数已移除，需要手动 `await client.start()`。

### 7. 版本号
- `requirements`: `github-copilot-sdk==0.2.2` → `1.0.2`
- `scripts/deploy_pipe.py`: `0.1.25` → `1.0.2`
- `scripts/sync_to_workspace.py`: `0.1.23` → `1.0.2`

## 验证
通过本地 `pip install github-copilot-sdk==1.0.2` 验证所有 API 变更：
- `SessionMode` 枚举成员: `INTERACTIVE/PLAN/AUTOPILOT` ✓
- `ModeSetRequest` 字段: `mode` ✓
- `resume_session` 参数包含 `config_directory`（非 `config_dir`）✓
- `CopilotClient` 接受关键字参数，无 `auto_start` ✓
- `SubprocessConfig` 不再可导入 ✓
- `SessionConfig` 不再可导入 ✓
- `StdioRuntimeConnection` 可从 `copilot` 导入 ✓

代码语法检查通过（`python -m py_compile`）。

Closes #79
