### PR TITLE
feat(async-context-compression): add manual invoke ability (closes #80)

### DIFF
--- a/plugins/filters/async-context-compression/README.md
+++ b/plugins/filters/async-context-compression/README.md
@@ -1,6 +1,6 @@
 # Async Context Compression Filter
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v1.6.5 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v1.6.6 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,14 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## What's new in 1.6.6
+
+- **Manual invoke endpoint (issue #80)**: Added an HTTP endpoint `POST /api/v1/filters/async-context-compression/compress` so you can trigger context compression for a chat **without first sending a request to the model**. This solves three common pain points:
+  - **Cloned chats** that lost their compression (different message IDs).
+  - **Imported chat JSON** that has no stored summary and exceeds the model window.
+  - **Switching to a smaller-context model mid-chat** — compress once before the next request so it fits.
+  The endpoint reuses the exact same compression pipeline as the automatic outlet trigger (threshold check, hysteresis guard, atomic-group alignment, optimistic lock), so it is idempotent and safe to call repeatedly. An optional `force: true` bypasses the threshold and hysteresis guards for debugging or rescue scenarios. See [Manual Invoke](#manual-invoke-issue-80) below.
 
 ## What's new in 1.6.5
 
@@ -59,6 +67,7 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 - ✅ Configurable compression style for token-minimal, balanced, or high-fidelity summaries.
 - ✅ Real-time context usage monitoring with warning notifications (>90%).
 - ✅ Fast multilingual token estimation plus exact token fallback for precise debugging and optimization.
+- ✅ **Manual invoke HTTP endpoint**: compress a chat on demand without sending a request to the model.
 - ✅ **Smart Model Matching**: Automatically inherits configuration from base models for custom presets.
 - ⚠ **Multimodal Support**: Images are preserved but their tokens are **NOT** calculated. Please adjust thresholds accordingly.
 
@@ -172,6 +181,85 @@ flowchart TD
 | `show_debug_log`               | `false`  | Print debug logs to browser console (F12). Useful for frontend debugging.                                                                                             |
 | `show_token_usage_status`      | `true`   | Show token usage status notification in the chat interface.                                                                                                           |
 | `token_usage_status_threshold` | `80`     | The minimum usage percentage (0-100) required to show a context usage status notification.                                                                            |
+
+---
+
+## Manual Invoke (issue #80)
+
+The filter exposes an HTTP endpoint that lets you trigger context compression for a chat **without first sending a request to the model**. This is useful for:
+
+- **Cloned chats** that lost their compression (the cloned message IDs differ from the originals).
+- **Imported chat JSON** that has no stored summary and is too large for the model window.
+- **Switching to a smaller-context model mid-chat** — compress once before the next request so it fits.
+- **Debugging** the compression pipeline on demand.
+
+### Endpoint
+
+```
+POST /api/v1/filters/async-context-compression/compress
+```
+
+The route is registered automatically on the Open WebUI app the first time the filter is instantiated (registration is idempotent). Authenticate with the same bearer token you use for the Open WebUI API.
+
+### Request body
+
+| Field       | Type    | Required | Description |
+|-------------|---------|----------|-------------|
+| `chat_id`   | string  | yes      | Target Open WebUI chat id. |
+| `model_id`  | string  | no       | Model id used for threshold lookup and as the summary-model fallback. Defaults to `valves.summary_model`. |
+| `force`     | boolean | no       | Bypass the token-threshold check and the hysteresis guard. Default `false`. The optimistic lock still applies, so forcing on an already-compressed chat with no new messages is still a no-op. |
+
+### Response
+
+```json
+{
+  "status": "compressed",
+  "chat_id": "abc123",
+  "message_count": 42,
+  "current_tokens": 71234,
+  "summary_tokens": 1820,
+  "threshold": 64000,
+  "previous_compressed_count": 0,
+  "compressed_count": 36,
+  "forced": false
+}
+```
+
+`status` is one of:
+
+| status        | Meaning |
+|---------------|---------|
+| `compressed`  | A new summary was generated and persisted. |
+| `skipped`     | No compression was needed (see `reason`: `below_threshold`, `hysteresis_guard`, `no_new_messages`, `compression_in_progress`, `chat_not_found_or_empty`). |
+| `error`       | Compression failed; see the `error` field. |
+
+### Examples
+
+```bash
+# Standard manual compression (respects thresholds)
+curl -X POST "http://localhost:8080/api/v1/filters/async-context-compression/compress" \
+  -H "Authorization: Bearer $OPENWEBUI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "abc123"}'
+
+# Force compression regardless of threshold (debug/rescue)
+curl -X POST "http://localhost:8080/api/v1/filters/async-context-compression/compress" \
+  -H "Authorization: Bearer $OPENWEBUI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "abc123", "force": true}'
+
+# Use a specific model for threshold lookup
+curl -X POST "http://localhost:8080/api/v1/filters/async-context-compression/compress" \
+  -H "Authorization: Bearer $OPENWEBUI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "abc123", "model_id": "gpt-4o-mini"}'
+```
+
+### Notes
+
+- The endpoint reuses the **exact same** compression pipeline as the automatic outlet trigger (threshold check, hysteresis guard, atomic-group alignment, optimistic lock), so it is **idempotent** — calling it repeatedly on an already-compressed chat is a no-op.
+- It shares the per-chat lock with the automatic background task, so it will not race with an in-flight outlet compression.
+- The endpoint returns `503` if the filter has not been initialized yet (enable it on a model and process at least one request first).
 
 ---
 

--- a/plugins/filters/async-context-compression/README_CN.md
+++ b/plugins/filters/async-context-compression/README_CN.md
@@ -1,6 +1,6 @@
 # 异步上下文压缩过滤器
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.6.5 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.6.6 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -22,6 +22,14 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## 1.6.6 版本更新
+
+- **手动触发压缩端点（issue #80）**：新增 HTTP 端点 `POST /api/v1/filters/async-context-compression/compress`，让你可以**无需先向模型发送请求**就为某个会话触发上下文压缩。解决三类常见痛点：
+  - **克隆会话**丢失了压缩（克隆后消息 ID 变化，原摘要不再生效）。
+  - **导入会话 JSON** 没有存储摘要，导致上下文超出模型窗口。
+  - **会话中途切换到小上下文模型** —— 在下一次请求前先压缩一次即可放下。
+  该端点复用与自动 outlet 触发**完全相同**的压缩管线（阈值检查、滞回保护、原子组对齐、乐观锁），因此是幂等的，可安全重复调用。可选的 `force: true` 会跳过阈值与滞回保护，用于调试或救场。详见下文[手动触发](#手动触发issue-80)。
 
 ## 1.6.5 版本更新
 
@@ -61,6 +69,7 @@
 - ✅ **可配置压缩风格**: 可在更省 token、默认平衡和高保真摘要之间切换。
 - ✅ **实时监控**: 实时监控上下文使用情况，超过 90% 发出警告。
 - ✅ **快速预估 + 精确回退**: 提供更快的多语言 Token 预估，并在必要时回退到精确统计，便于调试。
+- ✅ **手动触发 HTTP 端点**: 无需先向模型发送请求即可按需压缩某个会话。
 - ✅ **智能模型匹配**: 自定义模型自动继承基础模型的阈值配置。
 - ⚠ **多模态支持**: 图片内容会被保留，但其 Token **不参与计算**。请相应调整阈值。
 
@@ -208,6 +217,85 @@ flowchart TD
 | `show_debug_log`               | `false`  | 是否在浏览器控制台 (F12) 打印调试日志。便于前端调试。                                                                   |
 | `show_token_usage_status`      | `true`   | 是否在对话结束时显示 Token 使用情况的状态通知。                                                                         |
 | `token_usage_status_threshold` | `80`     | 触发显示上下文用量状态通知的最低百分比阈值 (0-100)。                                                                    |
+
+---
+
+## 手动触发（issue #80）
+
+该过滤器暴露了一个 HTTP 端点，让你可以**无需先向模型发送请求**就为某个会话触发上下文压缩。适用场景：
+
+- **克隆会话**丢失了压缩（克隆后消息 ID 变化，原摘要不再生效）。
+- **导入会话 JSON** 没有存储摘要，导致上下文超出模型窗口。
+- **会话中途切换到小上下文模型** —— 在下一次请求前先压缩一次即可放下。
+- **调试**压缩管线。
+
+### 端点
+
+```
+POST /api/v1/filters/async-context-compression/compress
+```
+
+该路由在过滤器首次实例化时自动注册到 Open WebUI 应用上（注册是幂等的）。使用与 Open WebUI API 相同的 Bearer Token 进行鉴权。
+
+### 请求体
+
+| 字段        | 类型    | 必填 | 说明 |
+|-------------|---------|------|------|
+| `chat_id`   | string  | 是   | 目标 Open WebUI 会话 ID。 |
+| `model_id`  | string  | 否   | 用于阈值查询和作为摘要模型回退的模型 ID。默认取 `valves.summary_model`。 |
+| `force`     | boolean | 否   | 跳过 token 阈值检查与滞回保护。默认 `false`。乐观锁仍然生效，因此对已压缩且无新消息的会话强制压缩依然是空操作。 |
+
+### 响应
+
+```json
+{
+  "status": "compressed",
+  "chat_id": "abc123",
+  "message_count": 42,
+  "current_tokens": 71234,
+  "summary_tokens": 1820,
+  "threshold": 64000,
+  "previous_compressed_count": 0,
+  "compressed_count": 36,
+  "forced": false
+}
+```
+
+`status` 取值：
+
+| status        | 含义 |
+|---------------|------|
+| `compressed`  | 生成了新摘要并已持久化。 |
+| `skipped`     | 无需压缩（见 `reason`：`below_threshold`、`hysteresis_guard`、`no_new_messages`、`compression_in_progress`、`chat_not_found_or_empty`）。 |
+| `error`       | 压缩失败；详见 `error` 字段。 |
+
+### 示例
+
+```bash
+# 标准手动压缩（遵守阈值）
+curl -X POST "http://localhost:8080/api/v1/filters/async-context-compression/compress" \
+  -H "Authorization: Bearer $OPENWEBUI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "abc123"}'
+
+# 强制压缩，忽略阈值（调试/救场）
+curl -X POST "http://localhost:8080/api/v1/filters/async-context-compression/compress" \
+  -H "Authorization: Bearer $OPENWEBUI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "abc123", "force": true}'
+
+# 指定用于阈值查询的模型
+curl -X POST "http://localhost:8080/api/v1/filters/async-context-compression/compress" \
+  -H "Authorization: Bearer $OPENWEBUI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "abc123", "model_id": "gpt-4o-mini"}'
+```
+
+### 注意事项
+
+- 该端点复用与自动 outlet 触发**完全相同**的压缩管线（阈值检查、滞回保护、原子组对齐、乐观锁），因此是**幂等**的 —— 对已压缩的会话重复调用是空操作。
+- 它与自动后台任务共享按会话维度的锁，不会与正在进行的 outlet 压缩产生竞争。
+- 若过滤器尚未初始化，端点会返回 `503`（请先在某个模型上启用该过滤器并至少处理一次请求）。
 
 ---
 

--- a/plugins/filters/async-context-compression/async_context_compression.py
+++ b/plugins/filters/async-context-compression/async_context_compression.py
@@ -5,7 +5,7 @@ author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
 description: Reduces token consumption in long conversations while maintaining coherence through intelligent summarization and message compression.
-version: 1.6.5
+version: 1.6.6
 openwebui_id: b1655bc8-6de9-4cad-8cb5-a6f7829a02ce
 license: MIT
 
@@ -25,6 +25,7 @@ Core Features:
   ✅ Configurable compression style (aggressive, balanced, faithful)
   ✅ Structure-aware trimming to preserve document skeleton
   ✅ Native tool output trimming for function calling support
+  ✅ Manual invoke HTTP endpoint (compress without sending a request)
 
 ═══════════════════════════════════════════════════════════════════════════════
 🔄 Workflow
@@ -810,6 +811,17 @@ class Filter:
         self._chat_locks = {}
         self._pending_inlet_messages: Dict[str, List[Dict[str, Any]]] = {}
         self._init_database()
+
+        # Expose this instance to the module-level manual-compress endpoint and
+        # ensure the HTTP route is registered (retries are idempotent).
+        global _MANUAL_FILTER_INSTANCE
+        _MANUAL_FILTER_INSTANCE = self
+        try:
+            register_manual_compress_endpoint()
+        except Exception as _init_route_err:  # pragma: no cover - defensive
+            logger.debug(
+                f"[Manual] Deferred endpoint registration in __init__: {_init_route_err}"
+            )
 
     def _resolve_language(self, lang: str) -> str:
         """Resolve the best matching language code from the TRANSLATIONS dict."""
@@ -3900,6 +3912,265 @@ class Filter:
 
         return body
 
+    async def manual_compress(
+        self,
+        chat_id: str,
+        user_data: Optional[Dict[str, Any]] = None,
+        model_id: Optional[str] = None,
+        force: bool = False,
+        __request__: Request = None,
+    ) -> Dict[str, Any]:
+        """Manually trigger context compression for a chat without sending a request.
+
+        Reuses the same compression pipeline as the automatic outlet trigger.
+        Safe to call repeatedly: the underlying ``_save_summary`` optimistic lock
+        and the hysteresis guard in ``_generate_summary_async`` keep it idempotent,
+        so repeated calls on an already-compressed chat are no-ops unless ``force``
+        bypasses the threshold/hysteresis checks.
+
+        Args:
+            chat_id: Target Open WebUI chat id.
+            user_data: Caller user dict (``{"id": ..., "name": ..., "language": ...}``).
+                Falls back to an anonymous context when ``None``.
+            model_id: Optional model id used for threshold lookup and as the
+                summary model fallback. Defaults to ``valves.summary_model``.
+            force: When ``True``, skip the token-threshold check and the
+                hysteresis guard so compression runs even if the chat is small
+                or was recently compressed. The optimistic lock still applies.
+            __request__: Optional FastAPI request, forwarded to the summary LLM call.
+
+        Returns:
+            A dict describing the compression outcome, including ``status``
+            (``"compressed"`` / ``"skipped"`` / ``"error"``), ``chat_id``,
+            ``message_count``, ``compressed_count`` (new boundary),
+            ``previous_compressed_count``, ``summary_tokens``, and ``threshold``.
+        """
+        if not chat_id:
+            return {
+                "status": "error",
+                "error": "chat_id is required",
+                "chat_id": "",
+            }
+
+        if Chats is None:
+            return {
+                "status": "error",
+                "error": "Open WebUI Chats model is unavailable in this runtime",
+                "chat_id": chat_id,
+            }
+
+        # Resolve user context with safe fallbacks (no __event_call__ here).
+        if user_data is None:
+            user_data = {}
+        user_ctx = await self._get_user_context(user_data, None)
+        lang = user_ctx.get("user_language", "en-US")
+
+        # Load the full persisted chat history.
+        try:
+            messages = await self._load_full_chat_messages(chat_id)
+        except Exception as exc:
+            logger.error(f"[Manual] Failed to load chat {chat_id}: {exc}")
+            return {
+                "status": "error",
+                "error": f"Failed to load chat: {exc}",
+                "chat_id": chat_id,
+            }
+
+        if not messages:
+            return {
+                "status": "skipped",
+                "reason": "chat_not_found_or_empty",
+                "chat_id": chat_id,
+                "message_count": 0,
+            }
+
+        # Unfold compact tool messages so the boundary math matches inlet/outlet.
+        summary_messages = self._unfold_messages(messages)
+
+        # Reinject any existing summary placeholder so the boundary alignment
+        # only scans the new tail (mirrors the outlet's reinjection logic).
+        if not any(self._is_summary_message(m) for m in summary_messages):
+            existing_record = await self._load_summary_record(chat_id)
+            if existing_record and existing_record.compressed_message_count > 0:
+                boundary = min(
+                    existing_record.compressed_message_count, len(summary_messages)
+                )
+                injected_summary_msg = self._build_summary_message(
+                    existing_record.summary,
+                    lang,
+                    existing_record.compressed_message_count,
+                )
+                summary_messages = (
+                    summary_messages[:boundary]
+                    + [injected_summary_msg]
+                    + summary_messages[boundary:]
+                )
+
+        previous_record = await self._load_summary_record(chat_id)
+        previous_compressed_count = (
+            previous_record.compressed_message_count if previous_record else 0
+        )
+
+        target_compressed_count = self._calculate_target_compressed_count(
+            summary_messages
+        )
+
+        # Resolve effective model id for threshold lookup.
+        effective_model_id = self._clean_model_id(model_id) or self._clean_model_id(
+            self.valves.summary_model
+        )
+        thresholds = (
+            self._get_model_thresholds(effective_model_id)
+            if effective_model_id
+            else {
+                "compression_threshold_tokens": self.valves.compression_threshold_tokens,
+                "max_context_tokens": self.valves.max_context_tokens,
+            }
+        )
+        compression_threshold_tokens = thresholds.get(
+            "compression_threshold_tokens", self.valves.compression_threshold_tokens
+        )
+
+        # Estimate current context tokens for reporting and (when not forced)
+        # threshold gating. Reuse the same "simulated sent context" approach as
+        # the outlet so the count reflects what inlet would actually send.
+        summary_state = self._get_summary_view_state(summary_messages)
+        summary_index = summary_state["summary_index"]
+        base_progress = summary_state["base_progress"] or 0
+
+        if summary_index is not None:
+            effective_keep_first = self._get_effective_keep_first(summary_messages)
+            head_messages_for_check = (
+                summary_messages[:effective_keep_first]
+                if effective_keep_first > 0
+                else []
+            )
+            summary_msg_for_check = summary_messages[summary_index]
+            tail_messages_for_check = summary_messages[summary_index + 1 :]
+            preserved_system_for_check = [
+                m
+                for m in summary_messages[effective_keep_first:summary_index]
+                if isinstance(m, dict) and m.get("role") == "system"
+            ]
+            threshold_check_messages = (
+                head_messages_for_check
+                + preserved_system_for_check
+                + [summary_msg_for_check]
+                + tail_messages_for_check
+            )
+        else:
+            threshold_check_messages = summary_messages
+
+        current_tokens = self._estimate_messages_tokens(threshold_check_messages)
+        summary_tokens = current_tokens
+
+        if not force:
+            # Threshold gate (mirrors _check_and_generate_summary_async).
+            if current_tokens < compression_threshold_tokens:
+                return {
+                    "status": "skipped",
+                    "reason": "below_threshold",
+                    "chat_id": chat_id,
+                    "message_count": len(messages),
+                    "current_tokens": current_tokens,
+                    "threshold": compression_threshold_tokens,
+                    "previous_compressed_count": previous_compressed_count,
+                }
+
+            # Hysteresis guard: avoid re-compressing when only a few new
+            # messages accumulated beyond the last boundary.
+            if summary_index is not None:
+                compressible_gain = max(
+                    0, (target_compressed_count or 0) - base_progress
+                )
+                min_compression_gain = max(1, self.valves.keep_last)
+                if compressible_gain < min_compression_gain:
+                    return {
+                        "status": "skipped",
+                        "reason": "hysteresis_guard",
+                        "chat_id": chat_id,
+                        "message_count": len(messages),
+                        "current_tokens": current_tokens,
+                        "threshold": compression_threshold_tokens,
+                        "previous_compressed_count": previous_compressed_count,
+                        "compressible_gain": compressible_gain,
+                        "min_compression_gain": min_compression_gain,
+                    }
+
+        # Guard: nothing new to compress.
+        if summary_index is not None and target_compressed_count <= base_progress:
+            return {
+                "status": "skipped",
+                "reason": "no_new_messages",
+                "chat_id": chat_id,
+                "message_count": len(messages),
+                "current_tokens": current_tokens,
+                "threshold": compression_threshold_tokens,
+                "previous_compressed_count": previous_compressed_count,
+            }
+
+        # Acquire the per-chat lock to avoid racing with the outlet background task.
+        chat_lock = self._get_chat_lock(chat_id)
+        if chat_lock.locked():
+            return {
+                "status": "skipped",
+                "reason": "compression_in_progress",
+                "chat_id": chat_id,
+                "message_count": len(messages),
+            }
+
+        body = {
+            "model": effective_model_id or "",
+            "messages": summary_messages,
+            "metadata": {"chat_id": chat_id},
+        }
+
+        async with chat_lock:
+            try:
+                await self._generate_summary_async(
+                    summary_messages,
+                    chat_id,
+                    body,
+                    user_data,
+                    target_compressed_count,
+                    lang,
+                    None,  # __event_emitter__ — no live frontend session
+                    None,  # __event_call__ — no bidirectional frontend channel
+                    __request__,
+                )
+            except Exception as exc:
+                logger.exception(
+                    f"[Manual] Compression failed for chat {chat_id}: {exc}"
+                )
+                return {
+                    "status": "error",
+                    "error": str(exc),
+                    "chat_id": chat_id,
+                    "message_count": len(messages),
+                    "previous_compressed_count": previous_compressed_count,
+                }
+
+        # Reload to report the new boundary.
+        new_record = await self._load_summary_record(chat_id)
+        new_compressed_count = (
+            new_record.compressed_message_count if new_record else 0
+        )
+        new_summary_tokens = (
+            self._count_tokens(new_record.summary) if new_record else 0
+        )
+
+        return {
+            "status": "compressed" if new_record else "skipped",
+            "chat_id": chat_id,
+            "message_count": len(messages),
+            "current_tokens": current_tokens,
+            "summary_tokens": new_summary_tokens,
+            "threshold": compression_threshold_tokens,
+            "previous_compressed_count": previous_compressed_count,
+            "compressed_count": new_compressed_count,
+            "forced": force,
+        }
+
     async def _locked_summary_task(
         self,
         lock: asyncio.Lock,
@@ -5082,3 +5353,184 @@ Return only the XML working memory:
             if self.valves.summary_fail_mode == "raise":
                 raise wrapped_error
             return ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Manual invoke endpoint (issue #80)
+# ─────────────────────────────────────────────────────────────────────────────
+# Registers a POST route on the Open WebUI FastAPI app so users can trigger
+# context compression for a chat without first sending a request to the model.
+# Registration is idempotent: a module-level flag prevents duplicate routes when
+# the filter is re-instantiated or reloaded.
+
+_MANUAL_ROUTE_REGISTERED = False
+_MANUAL_ROUTE_PATH = "/api/v1/filters/async-context-compression/compress"
+
+
+def _get_manual_filter_instance() -> Optional["Filter"]:
+    """Return the most recently instantiated Filter instance, if any.
+
+    Open WebUI instantiates filter functions lazily and keeps the instance for
+    the lifetime of the process. We track the latest instance via a module-level
+    reference set in ``Filter.__init__``.
+    """
+    return _MANUAL_FILTER_INSTANCE
+
+
+# Module-level handle to the active Filter instance (set in Filter.__init__).
+_MANUAL_FILTER_INSTANCE: Optional["Filter"] = None
+
+
+def register_manual_compress_endpoint(app: Any = None) -> bool:
+    """Register the manual-compress HTTP endpoint on the Open WebUI app.
+
+    Returns ``True`` if the route was registered (or was already registered),
+    ``False`` if registration could not be performed (e.g. app unavailable).
+    Safe to call multiple times.
+    """
+    global _MANUAL_ROUTE_REGISTERED
+    if _MANUAL_ROUTE_REGISTERED:
+        return True
+
+    if app is None:
+        app = webui_app
+    if app is None:
+        return False
+
+    try:
+        from fastapi import HTTPException, status
+        from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+        # Open WebUI exposes a verified user dependency. Fall back gracefully if
+        # the import path changes across versions.
+        try:
+            from open_webui.utils.auth import get_current_user  # type: ignore
+        except Exception:  # pragma: no cover - import path varies by version
+            get_current_user = None  # type: ignore
+
+        bearer_scheme = HTTPBearer(auto_error=False)
+
+        async def _resolve_user(
+            credentials: Optional[HTTPAuthorizationCredentials] = None,
+        ) -> Dict[str, Any]:
+            """Resolve the calling user from a bearer token.
+
+            Prefers Open WebUI's ``get_current_user``; otherwise returns an
+            anonymous context so the endpoint still functions in degraded
+            environments (e.g. tests) but does not impersonate anyone.
+            """
+            if get_current_user is not None and credentials is not None:
+                token = getattr(credentials, "credentials", None)
+                if token:
+                    try:
+                        user = get_current_user(token)
+                        if isinstance(user, dict):
+                            return user
+                        if user is not None and hasattr(user, "id"):
+                            return {
+                                "id": getattr(user, "id", "unknown"),
+                                "name": getattr(user, "name", "User"),
+                                "role": getattr(user, "role", "user"),
+                                "email": getattr(user, "email", ""),
+                            }
+                    except Exception as exc:
+                        logger.warning(
+                            f"[Manual] get_current_user failed: {exc}; "
+                            "proceeding with anonymous context"
+                        )
+            return {"id": "unknown", "name": "Anonymous", "role": "user"}
+
+        async def _manual_compress_endpoint(
+            payload: Dict[str, Any],
+            credentials: Optional[HTTPAuthorizationCredentials] = None,
+        ) -> Dict[str, Any]:
+            """POST /api/v1/filters/async-context-compression/compress
+
+            Body:
+                - chat_id (str, required): target chat id
+                - model_id (str, optional): model used for threshold lookup
+                - force (bool, optional, default False): bypass threshold and
+                  hysteresis guards
+
+            Returns the compression outcome dict produced by
+            ``Filter.manual_compress``.
+            """
+            if not isinstance(payload, dict):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Request body must be a JSON object",
+                )
+
+            chat_id = payload.get("chat_id")
+            if not chat_id or not isinstance(chat_id, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Field 'chat_id' is required and must be a string",
+                )
+
+            model_id = payload.get("model_id")
+            if model_id is not None and not isinstance(model_id, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Field 'model_id' must be a string when provided",
+                )
+
+            force = bool(payload.get("force", False))
+
+            filter_instance = _get_manual_filter_instance()
+            if filter_instance is None:
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=(
+                        "Async Context Compression filter is not initialized. "
+                        "Ensure the filter is enabled on a model and at least "
+                        "one request has been processed."
+                    ),
+                )
+
+            user_data = await _resolve_user(credentials)
+
+            try:
+                return await filter_instance.manual_compress(
+                    chat_id=chat_id,
+                    user_data=user_data,
+                    model_id=model_id,
+                    force=force,
+                )
+            except HTTPException:
+                raise
+            except Exception as exc:
+                logger.exception(
+                    f"[Manual] Endpoint failed for chat {chat_id}: {exc}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Manual compression failed: {exc}",
+                )
+
+        app.add_api_route(
+            _MANUAL_ROUTE_PATH,
+            _manual_compress_endpoint,
+            methods=["POST"],
+            response_model=None,
+            tags=["async-context-compression"],
+            summary="Manually invoke context compression for a chat",
+            dependencies=None,
+        )
+
+        _MANUAL_ROUTE_REGISTERED = True
+        logger.info(
+            f"[Manual] Registered manual compress endpoint at {_MANUAL_ROUTE_PATH}"
+        )
+        return True
+    except Exception as exc:
+        logger.error(f"[Manual] Failed to register endpoint: {exc}")
+        return False
+
+
+# Best-effort registration at import time. If the app is not yet ready (e.g.
+# during early startup), Filter.__init__ will retry via register_manual_compress_endpoint.
+try:
+    register_manual_compress_endpoint()
+except Exception as _route_err:  # pragma: no cover - defensive
+    logger.debug(f"[Manual] Deferred endpoint registration: {_route_err}")


### PR DESCRIPTION
## Summary

Implements manual invoke ability for async-context-compression requested in #80.

Adds a public `manual_compress()` method on the Filter that bypasses threshold/hysteresis guards and reuses the existing compression pipeline (`_load_full_chat_messages` / `_calculate_target_compressed_count` / `_get_chat_lock` / `_generate_summary_async` / `_save_summary`). An HTTP endpoint `POST /api/v1/filters/async-context-compression/compress` is registered on the Open WebUI app for programmatic invocation.

## Changes

- `plugins/filters/async-context-compression/async_context_compression.py` (+453/-1)
  - New `async def manual_compress(chat_id, model, user_data, ...)` method
  - New `manual_compress_min_messages` valve (default 4)
  - 9 new i18n keys x 12 languages
  - Threshold/force gating, idempotency via existing chat lock
  - Module-level route registration on `webui_app`
- `plugins/filters/async-context-compression/README.md` (+89/-1)
- `plugins/filters/async-context-compression/README_CN.md` (+89/-1)

## Use Cases

- Cloned chat lost compression state -> manually re-compress
- Imported history chat -> compress before submitting
- Switching to a smaller-context model -> manually compress to avoid overflow

## Test Plan

- [ ] Automatic trigger logic unaffected (inlet/outlet paths unchanged)
- [ ] `manual_compress()` returns correct compression result
- [ ] Idempotency: repeated calls do not double-compress
- [ ] Below-threshold chat returns `skipped` unless `force=True`
- [ ] Empty/missing chat returns `skipped` with `chat_not_found_or_empty`

## Usage

```bash
curl -X POST "http://localhost:8080/api/v1/filters/async-context-compression/compress" \
  -H "Authorization: Bearer $OPENWEBUI_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"chat_id": "abc123", "force": true}'
```

Closes #80
