### PR TITLE
fix(export_to_docx): render Mermaid diagrams with <br> labels — v0.5.2

### DIFF
--- a/plugins/actions/export_to_docx/README.md
+++ b/plugins/actions/export_to_docx/README.md
@@ -1,6 +1,6 @@
 # 📝 Export to Word (Enhanced)
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v0.5.1 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v0.5.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -21,12 +21,19 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
 
-## 🔥 What's New in v0.5.1
+## 🔥 What's New in v0.5.2
+
+- 📊 **Mermaid Diagrams with `<br>` Labels**: Diagrams whose labels contain `<br>` line breaks exported as a blank square. Mermaid 11 emits `<foreignObject>` HTML labels even with the per-diagram `htmlLabels:false`, and an unclosed `<br>` makes the SVG invalid XML — so it fails to rasterize to PNG. Setting `htmlLabels:false` at the **top level** of `mermaid.initialize` suppresses `<foreignObject>` entirely; labels render as native SVG text and diagrams rasterize correctly.
+
+<details>
+<summary>v0.5.1 changes</summary>
 
 - 🛠️ **Open WebUI 0.10.x Compatibility (Critical)**: OWUI 0.10 moved assistant replies into a structured `output` field and left `content` empty, breaking export with "No content found to export!". Assistant text is now recovered via `ChatMessages` + `convert_output_to_messages` (OpenWebUI-native, reasoning excluded). **Requires OWUI ≥ 0.10.2.**
 - 🖼️ **Unified Storage for File Images**: Replaced the hand-rolled `boto3`/S3 + multi-path disk fallbacks with OpenWebUI's `Storage` provider — local/S3/GCS/Azure all work via OWUI's own storage config. **`boto3` dependency dropped.**
 - 🌐 **Opt-in External Image Embedding**: New `EMBED_EXTERNAL_IMAGES` valve (off by default) downloads and embeds `![](https://…)` images, fetched through OWUI's SSRF-safe `validate_url` + `get_ssrf_safe_session`, capped by `MAX_EMBED_IMAGE_MB`.
 - 🧹 **Reference-Definition Stripping**: Markdown `[label]: target` lines (invisible in chat) are now stripped from the export, matching OpenWebUI's `removeFormattings`.
+
+</details>
 
 <details>
 <summary>v0.5.0 changes</summary>

--- a/plugins/actions/export_to_docx/README_CN.md
+++ b/plugins/actions/export_to_docx/README_CN.md
@@ -1,6 +1,6 @@
 # 📝 导出为 Word (增强版)
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.5.1 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.5.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -21,12 +21,19 @@
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
 
-## 🔥 v0.5.1 更新内容
+## 🔥 v0.5.2 更新内容
+
+- 📊 **含 `<br>` 标签的 Mermaid 图表**: 标签中包含 `<br>` 换行的图表会导出为空白方块。Mermaid 11 即使设置了每图的 `htmlLabels:false` 仍会生成 `<foreignObject>` HTML 标签，而未闭合的 `<br>` 使 SVG 成为无效 XML——因此无法栅格化为 PNG。现在在 `mermaid.initialize` 的**顶层**设置 `htmlLabels:false`，彻底禁用 `<foreignObject>`；标签渲染为原生 SVG 文本，图表可正确栅格化。
+
+<details>
+<summary>v0.5.1 更新内容</summary>
 
 - 🛠️ **Open WebUI 0.10.x 兼容性修复（关键）**: OWUI 0.10 将助手回复迁移到结构化 `output` 字段，`content` 变空，导致导出报错 "No content found to export!"。现在通过 `ChatMessages` + `convert_output_to_messages` 用 OpenWebUI 原生方式恢复助手文本（排除推理内容）。**要求 OWUI ≥ 0.10.2。**
 - 🖼️ **统一文件图片存储**: 移除手搓的 `boto3`/S3 + 多路径磁盘回退，改用 OpenWebUI 的 `Storage` 提供器——本地/S3/GCS/Azure 均通过 OWUI 自身的存储配置解析。**移除了 `boto3` 依赖。**
 - 🌐 **可选的外部图片嵌入**: 新增 `嵌入外部图片` 阀门（默认关闭），下载并嵌入 `![](https://…)` 图片，通过 OWUI 的 SSRF 安全 `validate_url` + `get_ssrf_safe_session` 获取，受 `最大嵌入图片大小MB` 限制。
 - 🧹 **引用定义剥离**: Markdown `[label]: target` 行（对话中不可见）现已从导出中剥离，与 OpenWebUI 的 `removeFormattings` 一致。
+
+</details>
 
 <details>
 <summary>v0.5.0 更新内容</summary>

--- a/plugins/actions/export_to_docx/export_to_word.py
+++ b/plugins/actions/export_to_docx/export_to_word.py
@@ -3,7 +3,7 @@ title: Export to Word Enhanced
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 0.5.1
+version: 0.5.2
 required_open_webui_version: 0.10.2
 openwebui_id: fca6a315-2a45-42cc-8c96-55cbc85f87f2
 icon_url: data:image/svg+xml;base64,PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNNiAyMmEyIDIgMCAwIDEtMi0yVjRhMiAyIDAgMCAxIDItMmg4YTIuNCAyLjQgMCAwIDEgMS43MDQuNzA2bDMuNTg4IDMuNTg4QTIuNCAyLjQgMCAwIDEgMjAgOHYxMmEyIDIgMCAwIDEtMiAyeiIgLz4KICA8cGF0aCBkPSJNMTQgMnY1YTEgMSAwIDAgMCAxIDFoNSIgLz4KICA8cGF0aCBkPSJNMTAgOUg4IiAvPgogIDxwYXRoIGQ9Ik0xNiAxM0g4IiAvPgogIDxwYXRoIGQ9Ik0xNiAxN0g4IiAvPgo8L3N2Zz4K
@@ -908,6 +908,7 @@ class Action:
 			                                                themeCSS: ".slice {{ font-size: 10pt !important; }}\\n.legend text {{ font-size: 10pt !important; }}\\n.pieTitleText {{ font-size: 10pt !important; }}",
 			                                                fontFamily: "Calibri, Segoe UI, Arial, sans-serif",
 			                                                securityLevel: "strict",
+			                                                htmlLabels: false,
 			                                                flowchart: {{ htmlLabels: false }},
 			                                            }});
 	                                        }} catch (_e) {{

--- a/plugins/actions/export_to_docx/export_to_word_cn.py
+++ b/plugins/actions/export_to_docx/export_to_word_cn.py
@@ -3,7 +3,7 @@ title: 导出为Word增强版
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 0.5.1
+version: 0.5.2
 required_open_webui_version: 0.10.2
 openwebui_id: 8a6306c0-d005-4e46-aaae-8db3532c9ed5
 icon_url: data:image/svg+xml;base64,PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNNiAyMmEyIDIgMCAwIDEtMi0yVjRhMiAyIDAgMCAxIDItMmg4YTIuNCAyLjQgMCAwIDEgMS43MDQuNzA2bDMuNTg4IDMuNTg4QTIuNCAyLjQgMCAwIDEgMjAgOHYxMmEyIDIgMCAwIDEtMiAyeiIgLz4KICA8cGF0aCBkPSJNMTQgMnY1YTEgMSAwIDAgMCAxIDFoNSIgLz4KICA8cGF0aCBkPSJNMTAgOUg4IiAvPgogIDxwYXRoIGQ9Ik0xNiAxM0g4IiAvPgogIDxwYXRoIGQ9Ik0xNiAxN0g4IiAvPgo8L3N2Zz4K
@@ -908,6 +908,7 @@ class Action:
 			                                                themeCSS: ".slice {{ font-size: 10pt !important; }}\\n.legend text {{ font-size: 10pt !important; }}\\n.pieTitleText {{ font-size: 10pt !important; }}",
 			                                                fontFamily: "Calibri, Segoe UI, Arial, sans-serif",
 			                                                securityLevel: "strict",
+			                                                htmlLabels: false,
 			                                                flowchart: {{ htmlLabels: false }},
 			                                            }});
 	                                        }} catch (_e) {{

--- a/plugins/actions/export_to_docx/v0.5.2.md
+++ b/plugins/actions/export_to_docx/v0.5.2.md
@@ -1,0 +1,27 @@
+# Export to Word Enhanced — v0.5.2 Release Notes
+
+**Release Date:** 2026-07-09
+**Author:** [Fu-Jie](https://github.com/Fu-Jie)
+**Version:** 0.5.2
+
+---
+
+## What's New
+
+### 📊 Mermaid Diagrams with `<br>` Labels Now Render
+
+Mermaid diagrams whose node or edge labels contain `<br>` line breaks previously exported as a blank square.
+
+Mermaid 11 emits `<foreignObject>` HTML labels even when the per-diagram `flowchart.htmlLabels` is set to `false`, and an unclosed `<br>` inside that HTML makes the rendered SVG invalid XML. The plugin rasterizes each diagram by loading its SVG into an `<img>` and drawing it onto a `<canvas>` — the invalid SVG fails to load, so nothing is drawn (a correctly-sized but blank square).
+
+Setting `htmlLabels: false` at the **top level** of `mermaid.initialize` (the per-diagram flag alone is ignored by Mermaid 11) suppresses `<foreignObject>` entirely: labels render as native SVG `<text>`, the SVG stays valid XML, and the diagram rasterizes correctly.
+
+---
+
+## Compatibility
+
+- No dependency or requirement changes. Still **requires Open WebUI ≥ 0.10.2**.
+
+---
+
+*For full commit history, see the [GitHub releases page](https://github.com/Fu-Jie/openwebui-extensions/releases).*

--- a/plugins/actions/export_to_docx/v0.5.2_CN.md
+++ b/plugins/actions/export_to_docx/v0.5.2_CN.md
@@ -1,0 +1,27 @@
+# Export to Word Enhanced — v0.5.2 版本发布说明
+
+**发布日期：** 2026-07-09
+**作者：** [Fu-Jie](https://github.com/Fu-Jie)
+**版本：** 0.5.2
+
+---
+
+## 最新更新
+
+### 📊 含 `<br>` 标签的 Mermaid 图表现已正常渲染
+
+标签（节点或连线）中包含 `<br>` 换行的 Mermaid 图表此前会导出为空白方块。
+
+Mermaid 11 即使将每图的 `flowchart.htmlLabels` 设为 `false`，仍会生成 `<foreignObject>` HTML 标签，而其中未闭合的 `<br>` 使渲染出的 SVG 成为无效 XML。插件通过将 SVG 加载到 `<img>` 再绘制到 `<canvas>` 来栅格化每个图表——无效的 SVG 无法加载，因此什么都没画出来（一个大小正确但空白的方块）。
+
+现在在 `mermaid.initialize` 的**顶层**设置 `htmlLabels: false`（Mermaid 11 会忽略仅在每图级别设置的该项），彻底禁用 `<foreignObject>`：标签渲染为原生 SVG `<text>`，SVG 保持有效 XML，图表可正确栅格化。
+
+---
+
+## 兼容性
+
+- 无依赖或要求变更。仍**要求 Open WebUI ≥ 0.10.2**。
+
+---
+
+*完整 commit 历史，请查看 [GitHub releases 页面](https://github.com/Fu-Jie/openwebui-extensions/releases)。*


### PR DESCRIPTION
## Summary
Mermaid diagrams whose node or edge labels contain `<br>` line breaks exported as a **blank square**.

Mermaid 11 emits `<foreignObject>` HTML labels even when the per-diagram `flowchart.htmlLabels` is set to `false`, and an unclosed `<br>` inside that HTML makes the rendered SVG **invalid XML**. The plugin rasterizes each diagram by loading its SVG into an `<img>` and drawing it onto a `<canvas>` — the invalid SVG fails to load (`img.onerror`), so nothing is drawn (a correctly-sized but blank square).

## Fix
Set `htmlLabels: false` at the **top level** of `mermaid.initialize` (the per-diagram flag alone is ignored by Mermaid 11). This suppresses `<foreignObject>` entirely: labels render as native SVG `<text>`, the SVG stays valid XML, and the diagram rasterizes correctly. Applied to `export_to_word.py` and `export_to_word_cn.py`.

## Verified
Reproduced and fixed headlessly against Mermaid 11.12.2 with the plugin's exact config:

| config | foreignObject | SVG loads | rasterized pixels |
| :-- | :-- | :-- | :-- |
| current (`flowchart.htmlLabels:false`) | yes | **fails** | 0 (blank) |
| + top-level `htmlLabels:false` | no | ok | 186,927 |

Also confirmed on a real multi-diagram export (flowchart + pie + xychart + timeline): every diagram renders as a valid, `foreignObject`-free, PNG-backed SVG.

## Compatibility
No dependency or requirement changes. Still requires **Open WebUI ≥ 0.10.2**.
