### PR TITLE
fix(release): only show "New Contributors" for genuine first-timers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,15 +567,13 @@ jobs:
             echo "" >> release_notes.md
           fi
 
-          # 4. Contributor attribution — inject when the release was triggered by an external contributor's PR
-          if [ "$CONTRIBUTOR_IS_EXTERNAL" = "true" ] && [ -n "$CONTRIBUTOR_PR_NUMBER" ] && [ -n "$CONTRIBUTOR_PR_AUTHOR" ]; then
+          # 4. Contributor attribution — only call out genuine first-time external
+          # contributors. Returning contributors are already credited via their
+          # PR in the changelog; labeling them "New Contributors" is incorrect.
+          if [ "$CONTRIBUTOR_IS_EXTERNAL" = "true" ] && [ "$CONTRIBUTOR_FIRST_TIME" = "true" ] && [ -n "$CONTRIBUTOR_PR_NUMBER" ] && [ -n "$CONTRIBUTOR_PR_AUTHOR" ]; then
             echo "## New Contributors" >> release_notes.md
             echo "" >> release_notes.md
-            if [ "$CONTRIBUTOR_FIRST_TIME" = "true" ]; then
-              echo "* @${CONTRIBUTOR_PR_AUTHOR} made their first contribution in #${CONTRIBUTOR_PR_NUMBER} 🎉" >> release_notes.md
-            else
-              echo "* @${CONTRIBUTOR_PR_AUTHOR} contributed in #${CONTRIBUTOR_PR_NUMBER}" >> release_notes.md
-            fi
+            echo "* @${CONTRIBUTOR_PR_AUTHOR} made their first contribution in #${CONTRIBUTOR_PR_NUMBER} 🎉" >> release_notes.md
             echo "" >> release_notes.md
           fi
 


### PR DESCRIPTION
## Problem

The release workflow's contributor-attribution step injected a `## New Contributors` section for **any** external contributor, not just first-time ones. The `first_time` flag only changed the bullet wording (`"made their first contribution 🎉"` vs `"contributed in"`), but the section **header** always said "New Contributors".

This caused returning contributors to be mislabeled as new. Example: `@rbb-dev` contributed #103 (released in `release-2026.07.02`), then #104 — but `release-2026.07.09` listed them under "New Contributors" again.

## Fix

Only emit the `## New Contributors` section when `CONTRIBUTOR_FIRST_TIME=true`. Returning contributors are already credited via their PR in the changelog and don't need a separate (incorrectly-labeled) callout.

**Before:**
```bash
if [ "$CONTRIBUTOR_IS_EXTERNAL" = "true" ] && ...; then
    echo "## New Contributors" >> release_notes.md   # ← always "New Contributors"
    if [ "$CONTRIBUTOR_FIRST_TIME" = "true" ]; then
        echo "* @... made their first contribution ..."   # first-timer
    else
        echo "* @... contributed in #..."                 # returning (wrong header!)
    fi
fi
```

**After:**
```bash
if [ "$CONTRIBUTOR_IS_EXTERNAL" = "true" ] && [ "$CONTRIBUTOR_FIRST_TIME" = "true" ] && ...; then
    echo "## New Contributors" >> release_notes.md
    echo "* @... made their first contribution in #... 🎉"
fi
```

## Already-fixed artifact

The already-published `release-2026.07.09` body had the incorrect section; it was edited in-place to remove the `## New Contributors` block (rbb-dev is not new — #103 was their first, in `release-2026.07.02`).

## Verification

- `release-2026.07.02` (rbb-dev #103): correctly says "made their first contribution in #103 🎉" ✅
- `release-2026.07.09` (rbb-dev #104): now has no "New Contributors" section ✅
- Future returning contributors: no longer mislabeled ✅
- Future genuine first-timers: still get the callout ✅