### PR TITLE
docs(async-context-compression): add v1.7.4 release notes and sync version across docs

### DIFF
--- a/docs/plugins/filters/async-context-compression.md
+++ b/docs/plugins/filters/async-context-compression.md
@@ -1,6 +1,6 @@
 # Async Context Compression Filter
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v1.7.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v1.7.4 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,19 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## What's new in 1.7.4
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` and `_call_db_sync` now use `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated filter sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods (`Users.get_user_by_id`, `Chats.get_chat_by_id`, `Models.get_model_by_id`) to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params' / 'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged. (Thanks to @linbanana for PR #107.)
+
+## What's new in 1.7.3
+
+- **Summary persistence on fresh PostgreSQL**: Fixed `DuplicateTable: relation "ix_chat_summary_chat_id" already exists` and the resulting `⚠️ Summary generated but was not persisted`. The shared SQLAlchemy metadata is now deduplicated before `CREATE TABLE`, and legacy colliding indexes are cleared idempotently.
+- **Outlet summary reuse for idless plain-chat branches**: When the outlet request carries a `chat_id` but no stable message refs, the filter now reads the active DB branch and aligns the body against it so the generated summary can be persisted and reused on subsequent turns.
+- **Reasoning-model inlet reuse (issue #98)**: Reasoning models store folded `<details type="reasoning">` content in the DB, but the request body reconstructed by `process_messages_with_output` strips or re-tags the reasoning, so cached summaries were rejected every turn. A new position-based fallback (Path 3) accepts the snapshot when body and DB branches have equal length and roles / tool_calls / tool_call_id match position-by-position. DB messages with an `output` array are exempted from content comparison; DB messages without `output` still require exact content equality, so edited or tampered bodies are rejected.
+- **Path 3 mixed-id fix**: `process_messages_with_output` only strips `output` (not `id`), so real reasoning-chat bodies are mixed-id — the all-idless guard was removed; Path 3 now accepts real reasoning chats.
+- **Path 3 diagnostic logging**: when Path 3 is eligible but a per-position check fails, `debug_mode` now logs the first failing index and the mismatched field (role / tool_calls / tool_call_id / content), so silent rejections are observable.
+- **End-to-end verification**: A new test module inlines `convert_output_to_messages`, `process_messages_with_output`, and `reconcile_tool_pairs` copied verbatim from the OpenWebUI main branch, and replays OpenAI-compatible / Ollama / llama.cpp / tool-call reasoning chats through the full `inlet()` entry point. The body builder mirrors the real pipeline exactly (genuinely mixed-id), with regression tests covering the mixed-id shape and Path 3 acceptance.
 
 ## What's new in 1.7.2
 
@@ -222,6 +235,6 @@ If this plugin has been useful, a star on [OpenWebUI Extensions](https://github.
 
 ## Changelog
 
-See [`v1.7.2` Release Notes](https://github.com/Fu-Jie/openwebui-extensions/blob/main/plugins/filters/async-context-compression/v1.7.2.md) for the release-specific summary.
+See [`v1.7.4` Release Notes](https://github.com/Fu-Jie/openwebui-extensions/blob/main/plugins/filters/async-context-compression/v1.7.4.md) for the release-specific summary.
 
 See the full history on GitHub: [OpenWebUI Extensions](https://github.com/Fu-Jie/openwebui-extensions)

--- a/docs/plugins/filters/async-context-compression.zh.md
+++ b/docs/plugins/filters/async-context-compression.zh.md
@@ -1,6 +1,6 @@
 # 异步上下文压缩过滤器
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.7.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.7.4 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -22,6 +22,19 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## 1.7.4 版本更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 和 `_call_db_sync` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的 filter 沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法（`Users.get_user_by_id`、`Chats.get_chat_by_id`、`Models.get_model_by_id`）被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params' / 'email'`。OpenWebUI < 0.9.0 上行为不变。（感谢 @linbanana 在 PR #107 中贡献。）
+
+## 1.7.3 版本更新
+
+- **新 PostgreSQL 上的 summary 持久化**：修复了 `DuplicateTable: relation "ix_chat_summary_chat_id" already exists` 以及随之出现的 `⚠️ Summary generated but was not persisted`。`CREATE TABLE` 之前会先对共享的 SQLAlchemy metadata 做索引去重，并幂等清理撞名的 legacy 索引。
+- **无 id 普通对话分支的 outlet summary 复用**：当 outlet 请求带 `chat_id` 但没有稳定 message refs 时，插件现在会读取数据库里的 active branch 并对齐 body，使生成的 summary 可以持久化并在后续轮次复用。
+- **Reasoning model 的 inlet 复用（issue #98）**：Reasoning model 在数据库里保存带折叠 `<details type="reasoning">` 的 content，但 `process_messages_with_output` 重建请求 body 时会剥离或改写 reasoning，导致缓存的 summary 每轮都被拒绝。新增的 position-based 兜底路径（Path 3）在 body 与 DB 分支长度相同、role / tool_calls / tool_call_id 按位置匹配时接受 snapshot。带 `output` 数组的 DB 消息豁免 content 比对；没有 `output` 的 DB 消息仍要求 content 精确匹配，因此被编辑或篡改的 body 会被拒绝。
+- **Path 3 混合 id 修复**：`process_messages_with_output` 只剥离 `output`（不剥离 `id`），真实 reasoning 对话的 body 是混合 id 的——all-idless 守卫已移除，Path 3 现在能接受真实 reasoning 对话。
+- **Path 3 诊断日志**：当 Path 3 满足条件但某个位置检查失败时，`debug_mode` 现在会记录第一个失败的位置索引和不匹配的字段（role / tool_calls / tool_call_id / content），让静默拒绝变得可见。
+- **端到端验证**：新增测试模块内联了从 OpenWebUI main 分支逐行复制的 `convert_output_to_messages`、`process_messages_with_output` 和 `reconcile_tool_pairs`，并对 OpenAI 兼容 / Ollama / llama.cpp / 带 tool_calls 的 reasoning 对话走完整 `inlet()` 入口进行回放验证。body 构造精确镜像真实管道（真正的混合 id），回归测试覆盖混合 id 形状和 Path 3 接受。
 
 ## 1.7.2 版本更新
 
@@ -257,6 +270,6 @@ flowchart TD
 
 ## 更新日志
 
-请查看 [`v1.7.2` 版本发布说明](https://github.com/Fu-Jie/openwebui-extensions/blob/main/plugins/filters/async-context-compression/v1.7.2_CN.md) 获取本次版本的独立发布摘要。
+请查看 [`v1.7.4` 版本发布说明](https://github.com/Fu-Jie/openwebui-extensions/blob/main/plugins/filters/async-context-compression/v1.7.4_CN.md) 获取本次版本的独立发布摘要。
 
 完整历史请查看 GitHub 项目： [OpenWebUI Extensions](https://github.com/Fu-Jie/openwebui-extensions)

--- a/docs/plugins/filters/index.md
+++ b/docs/plugins/filters/index.md
@@ -22,7 +22,7 @@ Filters act as middleware in the message pipeline:
 
     Reduces token consumption in long conversations with tunable compression styles, safer summary fallbacks, and clearer failure visibility.
 
-    **Version:** 1.7.2
+    **Version:** 1.7.4
 
     [:octicons-arrow-right-24: Documentation](async-context-compression.md)
 

--- a/docs/plugins/filters/index.zh.md
+++ b/docs/plugins/filters/index.zh.md
@@ -22,7 +22,7 @@ Filter 充当消息管线中的中间件：
 
     通过可调压缩风格、更稳健的摘要回退和更清晰的失败提示，降低长对话的 token 消耗并保持连贯性。
 
-    **版本：** 1.7.2
+    **版本：** 1.7.4
 
     [:octicons-arrow-right-24: 查看文档](async-context-compression.zh.md)
 

--- a/plugins/filters/async-context-compression/README.md
+++ b/plugins/filters/async-context-compression/README.md
@@ -1,6 +1,6 @@
 # Async Context Compression Filter
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v1.7.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v1.7.4 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -27,6 +27,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 - **Single-table persistence**: Branch-specific reusable coverage is stored as multiple rows in `chat_summary`; there is no separate current-pointer row. Branch-valid historical rows are retained so a future fork can reuse the nearest matching ancestor, even when the user branches from an older point.
 - **Protected-head tracking**: Summary rows remember how many leading messages were kept outside the summary. If the current `keep_first` policy no longer preserves those messages, the row is not reused as branch-valid coverage.
 - **Safe upgrade behavior**: Legacy summaries without coverage metadata are not trusted as coverage. The first turn after upgrading may send more raw context until a branch-valid summary row is generated.
+
+## What's new in 1.7.4
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` and `_call_db_sync` now use `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated filter sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods (`Users.get_user_by_id`, `Chats.get_chat_by_id`, `Models.get_model_by_id`) to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params' / 'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged. (Thanks to @linbanana for PR #107.)
 
 ## What's new in 1.7.3
 
@@ -230,6 +234,6 @@ If this plugin has been useful, a star on [OpenWebUI Extensions](https://github.
 
 ## Changelog
 
-See [`v1.7.3` Release Notes](https://github.com/Fu-Jie/openwebui-extensions/blob/main/plugins/filters/async-context-compression/v1.7.3.md) for the release-specific summary.
+See [`v1.7.4` Release Notes](https://github.com/Fu-Jie/openwebui-extensions/blob/main/plugins/filters/async-context-compression/v1.7.4.md) for the release-specific summary.
 
 See the full history on GitHub: [OpenWebUI Extensions](https://github.com/Fu-Jie/openwebui-extensions)

--- a/plugins/filters/async-context-compression/README_CN.md
+++ b/plugins/filters/async-context-compression/README_CN.md
@@ -1,6 +1,6 @@
 # 异步上下文压缩过滤器
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.7.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.7.4 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -29,6 +29,10 @@
 - **单表持久化**：分支专属的可复用覆盖范围以多行形式写入 `chat_summary`；不再保留单独的 current pointer 行。插件会保留 branch-valid 历史摘要行，使用户从更早位置分叉时仍能复用当前分支上最接近的祖先摘要。
 - **受保护头部追踪**：摘要行会记录有多少开头消息是在摘要之外按原文保留的。如果当前 `keep_first` 策略已经不再保留这些消息，该摘要行不会作为 branch-valid 覆盖范围复用。
 - **安全升级行为**：没有覆盖范围元数据的 legacy summary 不再被当成可信覆盖。升级后的第一轮对话可能会发送更多原始上下文，直到生成 branch-valid 摘要行。
+
+## 1.7.4 版本更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 和 `_call_db_sync` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的 filter 沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法（`Users.get_user_by_id`、`Chats.get_chat_by_id`、`Models.get_model_by_id`）被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params' / 'email'`。OpenWebUI < 0.9.0 上行为不变。（感谢 @linbanana 在 PR #107 中贡献。）
 
 ## 1.7.3 版本更新
 
@@ -271,6 +275,6 @@ flowchart TD
 
 ## 更新日志
 
-请查看 [`v1.7.3` 版本发布说明](https://github.com/Fu-Jie/openwebui-extensions/blob/main/plugins/filters/async-context-compression/v1.7.3_CN.md) 获取本次版本的独立发布摘要。
+请查看 [`v1.7.4` 版本发布说明](https://github.com/Fu-Jie/openwebui-extensions/blob/main/plugins/filters/async-context-compression/v1.7.4_CN.md) 获取本次版本的独立发布摘要。
 
 完整历史请查看 GitHub 项目： [OpenWebUI Extensions](https://github.com/Fu-Jie/openwebui-extensions)

--- a/plugins/filters/async-context-compression/v1.7.4.md
+++ b/plugins/filters/async-context-compression/v1.7.4.md
@@ -1,0 +1,25 @@
+# Async Context Compression v1.7.4 Release Notes
+
+## Overview
+
+This patch resolves async database compatibility errors that surfaced on OpenWebUI >= 0.9.0 (including v0.10.1). The previous version-gated dispatch in `_call_db` / `_call_db_sync` relied on `_owui_version_ge("0.9.0")`, which can fall back to `"0.0.0"` when the OpenWebUI version import fails inside an isolated filter sandbox. Under that fallback, async DB methods (`Users.get_user_by_id`, `Chats.get_chat_by_id`, `Models.get_model_by_id`) were invoked synchronously, producing runtime warnings and attribute errors. v1.7.4 replaces the version-string check with runtime coroutine detection, so the correct sync/async path is taken regardless of version-string mismatches.
+
+## Bug Fixes
+
+- **Runtime coroutine detection for DB methods**: `_call_db` now uses `iscoroutinefunction(method)` (and a secondary `asyncio.iscoroutine(res)` guard for lazy coroutines) to decide whether to `await`. `_call_db_sync` mirrors this for the synchronous entry points (still routing async results through a dedicated thread + event loop). Version-string detection is no longer required.
+- **Resolves `RuntimeWarning: coroutine '_call_db' was never awaited`**: the warning appeared when the version check misidentified an async DB method as sync and discarded the unawaited coroutine.
+- **Resolves `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**: downstream code received a coroutine object instead of the resolved `User` / `Chat` / `Model` row, then crashed accessing attributes. The coroutine is now resolved before the result is returned.
+
+## Compatibility
+
+- Behavior is unchanged on OpenWebUI < 0.9.0 (sync DB methods are still called directly; `iscoroutinefunction` returns `False`, so no event loop is spawned).
+- No new Valves, no database migration, no breaking changes to the filter interface.
+- The fix is purely internal to the DB-dispatch helpers; summary persistence, branch-aware reuse, and Path 3 reasoning-model behavior from v1.7.3 are all preserved.
+
+## Upgrade Notes
+
+Update or reinstall the filter so OpenWebUI's stored function content includes v1.7.4. No user action beyond reinstall is required. If you previously saw `coroutine '_call_db' was never awaited` or `'coroutine' object has no attribute '...'` in the OpenWebUI logs, this release resolves them.
+
+## Credits
+
+Thanks to [@linbanana](https://github.com/linbanana) for contributing this fix in PR #107.

--- a/plugins/filters/async-context-compression/v1.7.4_CN.md
+++ b/plugins/filters/async-context-compression/v1.7.4_CN.md
@@ -1,0 +1,25 @@
+# 异步上下文压缩 v1.7.4 版本发布说明
+
+## 概述
+
+本补丁修复了在 OpenWebUI >= 0.9.0（含 v0.10.1）上出现的异步数据库兼容性错误。此前 `_call_db` / `_call_db_sync` 中的版本判断依赖 `_owui_version_ge("0.9.0")`，但在隔离的 filter 沙箱里 OpenWebUI 版本导入有时会失败并回退到 `"0.0.0"`。回退后，异步 DB 方法（`Users.get_user_by_id`、`Chats.get_chat_by_id`、`Models.get_model_by_id`）被当作同步方法调用，从而产生运行时告警和属性错误。v1.7.4 用运行时协程检测替换了版本字符串判断，无论版本字符串是否匹配都能选择正确的同步/异步路径。
+
+## 修复内容
+
+- **DB 方法的运行时协程检测**：`_call_db` 现在用 `iscoroutinefunction(method)`（并对惰性协程增加 `asyncio.iscoroutine(res)` 二次判断）来决定是否 `await`。`_call_db_sync` 在同步入口处做了对应处理（异步结果仍走独立线程 + 事件循环）。不再需要版本字符串判断。
+- **解决 `RuntimeWarning: coroutine '_call_db' was never awaited`**：当版本检查把异步 DB 方法误判为同步、并丢弃了未 await 的协程时会出现该告警。
+- **解决 `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**：下游代码收到的是协程对象，而不是已解析的 `User` / `Chat` / `Model` 行，访问属性时崩溃。现在协程会在返回前完成解析。
+
+## 兼容性
+
+- OpenWebUI < 0.9.0 上行为不变（同步 DB 方法仍直接调用；`iscoroutinefunction` 返回 `False`，不会创建事件循环）。
+- 无新增 Valves、无数据库迁移、无破坏性接口变更。
+- 修复仅限于 DB 派发辅助函数内部；v1.7.3 的 summary 持久化、分支感知复用和 Path 3 reasoning-model 行为均保持不变。
+
+## 升级说明
+
+更新或重新安装过滤器，确保 OpenWebUI 中保存的 function 内容包含 v1.7.4。除了重新安装外无需其他操作。如果你此前在 OpenWebUI 日志里看到 `coroutine '_call_db' was never awaited` 或 `'coroutine' object has no attribute '...'`，本版本已解决。
+
+## 致谢
+
+感谢 [@linbanana](https://github.com/linbanana) 在 PR #107 中贡献此修复。


### PR DESCRIPTION
## What

Supplements the release documentation for async-context-compression v1.7.4 (the async DB compatibility fix from PR #107 by @linbanana), following the project's `release-prep` skill.

## Why

PR #107 only touched the `.py` file (code + docstring version bump). The `release-prep` skill requires 7-way version sync + bilingual release notes, which were missing. Additionally, the `docs/` files were **two versions behind** — v1.7.3 was never synced to `docs/plugins/filters/`, so this PR backfills both v1.7.3 and v1.7.4.

## Changes

- **New release notes**: `v1.7.4.md` / `v1.7.4_CN.md` (bilingual) — documents the `iscoroutinefunction` + `asyncio.iscoroutine` detection replacing version-string gating, resolving `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'` on OWUI >= 0.9.0 / v0.10.1
- **Version sync** v1.7.2 → v1.7.4 across 6 files:
  - `README.md` / `README_CN.md` (badge + What's New + Changelog link)
  - `docs/plugins/filters/async-context-compression.md` / `.zh.md` (badge + What's New + Changelog link)
  - `docs/plugins/filters/index.md` / `index.zh.md` (version number)
- **Backfill**: v1.7.3 What's New section added to `docs/` files (was missing from the v1.7.3 release)
- **Credit**: @linbanana credited for PR #107

## Verification

`python3 scripts/check_version_consistency.py` — async-context-compression is now fully consistent (remaining 3 mismatches are export_to_excel/docx CN files, unrelated to this PR).