### PR TITLE
fix(actions): async DB compatibility for 5 plugins

### DIFF
--- a/docs/plugins/actions/export-to-excel.md
+++ b/docs/plugins/actions/export-to-excel.md
@@ -1,10 +1,14 @@
 # Export to Excel
 
 <span class="category-badge action">Action</span>
-<span class="version-badge">v0.3.8</span>
+<span class="version-badge">v0.3.11</span>
 
 Export chat conversations to Excel spreadsheet format for analysis, archiving, and sharing.
 
+
+### What's New in v0.3.11
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` now uses `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated plugin sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ### What's New in v0.3.8
 - ⚡ **Open WebUI 0.9.x Compatibility**: Added runtime version detection and async DB call adapters for `Users.get_user_by_id` and `Chats.get_chat_by_id` — ensuring seamless compatibility with Open WebUI 0.9.x.

--- a/docs/plugins/actions/export-to-excel.zh.md
+++ b/docs/plugins/actions/export-to-excel.zh.md
@@ -1,10 +1,14 @@
 # Export to Excel（导出到 Excel）
 
 <span class="category-badge action">Action</span>
-<span class="version-badge">v0.3.9</span>
+<span class="version-badge">v0.3.11</span>
 
 将聊天记录导出为 Excel 表格，便于分析、归档和分享。
 
+
+### v0.3.11 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的插件沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params'/'email'`。OpenWebUI < 0.9.0 上行为不变。
 
 ### v0.3.9 更新内容
 - 📏 **可配置行高**：新增 `ROW_HEIGHT` 配置项，可控制数据行高度。设为 `0`（默认）根据内容自动调整，或设置固定值（如 `20`）以获得紧凑的单行显示。

--- a/docs/plugins/actions/export-to-word.md
+++ b/docs/plugins/actions/export-to-word.md
@@ -1,7 +1,7 @@
 # Export to Word
 
 <span class="category-badge action">Action</span>
-<span class="version-badge">v0.5.0</span>
+<span class="version-badge">v0.5.3</span>
 
 Export conversation to Word (.docx) with **syntax highlighting**, **native math equations**, **Mermaid diagrams**, **citations**, and **enhanced table formatting**.
 

--- a/docs/plugins/actions/export-to-word.zh.md
+++ b/docs/plugins/actions/export-to-word.zh.md
@@ -1,7 +1,7 @@
 # Export to Word（导出为 Word）
 
 <span class="category-badge action">Action</span>
-<span class="version-badge">v0.5.0</span>
+<span class="version-badge">v0.5.3</span>
 
 将当前对话导出为完美格式的 Word 文档，支持**代码语法高亮**、**原生数学公式**、**Mermaid 图表**、**引用资料**以及**增强表格**渲染。
 

--- a/docs/plugins/actions/export_to_docx.md
+++ b/docs/plugins/actions/export_to_docx.md
@@ -1,6 +1,6 @@
 # 📝 Export to Word (Enhanced)
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v0.5.0 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v0.5.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## 🔥 What's New in v0.5.3
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` now uses `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated plugin sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## 🔥 What's New in v0.5.0
 

--- a/docs/plugins/actions/export_to_docx.zh.md
+++ b/docs/plugins/actions/export_to_docx.zh.md
@@ -1,6 +1,6 @@
 # 📝 导出为 Word (增强版)
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.5.0 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.5.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## 🔥 v0.5.3 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的插件沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params'/'email'`。OpenWebUI < 0.9.0 上行为不变。
 
 ## 🔥 v0.5.0 更新内容
 

--- a/docs/plugins/actions/flash-card.md
+++ b/docs/plugins/actions/flash-card.md
@@ -2,7 +2,7 @@
 
 Generate polished learning flashcards from any text—title, summary, key points, tags, and category—ready for review and sharing.
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v0.2.4 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v0.2.5 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## What's New in v0.2.5
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `Users.get_user_by_id` was previously called without `await`, which returned a coroutine object instead of the user row on OWUI >= 0.9.0, causing `AttributeError: 'coroutine' object has no attribute 'email'`. The call is now wrapped in a new `_call_db` helper that uses `iscoroutinefunction` + `asyncio.iscoroutine` for runtime async detection. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## What's New
 

--- a/docs/plugins/actions/flash-card.zh.md
+++ b/docs/plugins/actions/flash-card.zh.md
@@ -2,7 +2,7 @@
 
 快速将文本提炼为精美的学习记忆卡片，自动抽取标题、摘要、关键要点、标签和分类，适合复习与分享。
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.2.4 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.2.5 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## v0.2.5 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：此前 `Users.get_user_by_id` 直接调用没有 `await`，在 OWUI >= 0.9.0 上返回的是协程对象而非用户记录，导致 `AttributeError: 'coroutine' object has no attribute 'email'`。现在已用新增的 `_call_db` helper 包装，该 helper 通过 `iscoroutinefunction` + `asyncio.iscoroutine` 进行运行时异步检测。OpenWebUI < 0.9.0 上行为不变。
 
 ## 🔥 最新更新 v0.2.4
 

--- a/docs/plugins/actions/index.md
+++ b/docs/plugins/actions/index.md
@@ -23,7 +23,7 @@ Actions are interactive plugins that:
 
     Intelligently analyzes text content and generates interactive mind maps with beautiful visualizations.
 
-    **Version:** 1.0.2
+    **Version:** 1.0.3
 
     [:octicons-arrow-right-24: Documentation](smart-mind-map.md)
 
@@ -33,7 +33,7 @@ Actions are interactive plugins that:
 
     Transform text into professional infographics using AntV visualization engine with various templates.
 
-    **Version:** 1.6.2
+    **Version:** 1.6.3
 
     [:octicons-arrow-right-24: Documentation](smart-infographic.md)
 
@@ -43,7 +43,7 @@ Actions are interactive plugins that:
 
     Quickly generates beautiful flashcards from text, extracting key points and categories.
 
-    **Version:** 0.2.4
+    **Version:** 0.2.5
 
     [:octicons-arrow-right-24: Documentation](flash-card.md)
 
@@ -53,7 +53,7 @@ Actions are interactive plugins that:
 
     Export chat conversations to Excel spreadsheet format for analysis and archiving.
 
-    **Version:** 0.3.9
+    **Version:** 0.3.11
 
     [:octicons-arrow-right-24: Documentation](export-to-excel.md)
 
@@ -63,7 +63,7 @@ Actions are interactive plugins that:
 
     Export the current conversation to a formatted Word doc with **syntax highlighting**, **native math equations**, **Mermaid diagrams**, **citations**, and **enhanced table formatting**.
 
-    **Version:** 0.5.0
+    **Version:** 0.5.3
 
     [:octicons-arrow-right-24: Documentation](export-to-word.md)
 

--- a/docs/plugins/actions/index.zh.md
+++ b/docs/plugins/actions/index.zh.md
@@ -23,7 +23,7 @@ Actions 是交互式插件，能够：
 
     智能分析文本并生成交互式、精美的思维导图。
 
-    **版本：** 1.0.2
+    **版本：** 1.0.3
 
     [:octicons-arrow-right-24: 查看文档](smart-mind-map.md)
 
@@ -33,7 +33,7 @@ Actions 是交互式插件，能够：
 
     使用 AntV 可视化引擎，将文本转成专业的信息图。
 
-    **版本：** 1.6.2
+    **版本：** 1.6.3
 
     [:octicons-arrow-right-24: 查看文档](smart-infographic.md)
 
@@ -43,7 +43,7 @@ Actions 是交互式插件，能够：
 
     快速生成精美的学习记忆卡片，非常适合学习和快速记忆。
 
-    **版本：** 0.2.4
+    **版本：** 0.2.5
 
     [:octicons-arrow-right-24: 查看文档](flash-card.md)
 
@@ -53,7 +53,7 @@ Actions 是交互式插件，能够：
 
     将聊天记录导出为 Excel 电子表格，方便分析或归档。
 
-    **版本：** 0.3.9
+    **版本：** 0.3.11
 
     [:octicons-arrow-right-24: 查看文档](export-to-excel.md)
 
@@ -63,7 +63,7 @@ Actions 是交互式插件，能够：
 
     将当前对话导出为完美格式的 Word 文档，支持**代码语法高亮**、**原生数学公式**、**Mermaid 图表**、**引用资料**以及**增强表格**渲染。
 
-    **版本：** 0.5.0
+    **版本：** 0.5.3
 
     [:octicons-arrow-right-24: 查看文档](export-to-word.md)
 

--- a/docs/plugins/actions/infographic.md
+++ b/docs/plugins/actions/infographic.md
@@ -1,6 +1,6 @@
 # Smart Infographic
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v1.6.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v1.6.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## What's New in v1.6.3
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` now uses `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated plugin sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## 🔥 What's New in v1.6.2
 

--- a/docs/plugins/actions/infographic.zh.md
+++ b/docs/plugins/actions/infographic.zh.md
@@ -1,6 +1,6 @@
 # 智能信息图
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.6.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.6.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## v1.6.3 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的插件沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params'/'email'`。OpenWebUI < 0.9.0 上行为不变。
 
 ## 🔥 最新更新 v1.6.2
 

--- a/docs/plugins/actions/smart-infographic.md
+++ b/docs/plugins/actions/smart-infographic.md
@@ -1,7 +1,7 @@
 # Smart Infographic
 
 <span class="category-badge action">Action</span>
-<span class="version-badge">v1.4.9</span>
+<span class="version-badge">v1.6.3</span>
 
 An AntV Infographic engine powered plugin that transforms long text into professional, beautiful infographics with a single click.
 

--- a/docs/plugins/actions/smart-infographic.zh.md
+++ b/docs/plugins/actions/smart-infographic.zh.md
@@ -1,7 +1,7 @@
 # Smart Infographic（智能信息图）
 
 <span class="category-badge action">Action</span>
-<span class="version-badge">v1.4.9</span>
+<span class="version-badge">v1.6.3</span>
 
 基于 AntV 信息图引擎，将长文本一键转成专业、美观的信息图。
 

--- a/docs/plugins/actions/smart-mind-map.md
+++ b/docs/plugins/actions/smart-mind-map.md
@@ -2,7 +2,7 @@
 
 Smart Mind Map is a powerful OpenWebUI action plugin that intelligently analyzes long-form text content and automatically generates interactive mind maps, helping users structure and visualize knowledge.
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v1.0.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v1.0.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -22,6 +22,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## What's New in v1.0.3
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` now uses `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated plugin sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## What's New in v1.0.2
 

--- a/docs/plugins/actions/smart-mind-map.zh.md
+++ b/docs/plugins/actions/smart-mind-map.zh.md
@@ -2,7 +2,7 @@
 
 思维导图是一个强大的 OpenWebUI 动作插件，能够智能分析长篇文本内容，自动生成交互式思维导图，帮助用户结构化和可视化知识。
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.0.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.0.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -22,6 +22,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## v1.0.3 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的插件沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params'/'email'`。OpenWebUI < 0.9.0 上行为不变。
 
 ## v1.0.2 最新更新
 

--- a/plugins/actions/export_to_docx/README.md
+++ b/plugins/actions/export_to_docx/README.md
@@ -1,6 +1,6 @@
 # 📝 Export to Word (Enhanced)
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v0.5.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v0.5.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## 🔥 What's New in v0.5.3
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` now uses `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated plugin sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## 🔥 What's New in v0.5.2
 

--- a/plugins/actions/export_to_docx/README_CN.md
+++ b/plugins/actions/export_to_docx/README_CN.md
@@ -1,6 +1,6 @@
 # 📝 导出为 Word (增强版)
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.5.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.5.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## 🔥 v0.5.3 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的插件沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params'/'email'`。OpenWebUI < 0.9.0 上行为不变。
 
 ## 🔥 v0.5.2 更新内容
 

--- a/plugins/actions/export_to_docx/export_to_word.py
+++ b/plugins/actions/export_to_docx/export_to_word.py
@@ -3,7 +3,7 @@ title: Export to Word Enhanced
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 0.5.2
+version: 0.5.3
 required_open_webui_version: 0.10.2
 openwebui_id: fca6a315-2a45-42cc-8c96-55cbc85f87f2
 icon_url: data:image/svg+xml;base64,PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNNiAyMmEyIDIgMCAwIDEtMi0yVjRhMiAyIDAgMCAxIDItMmg4YTIuNCAyLjQgMCAwIDEgMS43MDQuNzA2bDMuNTg4IDMuNTg4QTIuNCAyLjQgMCAwIDEgMjAgOHYxMmEyIDIgMCAwIDEtMiAyeiIgLz4KICA8cGF0aCBkPSJNMTQgMnY1YTEgMSAwIDAgMCAxIDFoNSIgLz4KICA8cGF0aCBkPSJNMTAgOUg4IiAvPgogIDxwYXRoIGQ9Ik0xNiAxM0g4IiAvPgogIDxwYXRoIGQ9Ik0xNiAxN0g4IiAvPgo8L3N2Zz4K
@@ -20,6 +20,7 @@ import datetime
 import time
 import io
 import asyncio
+from inspect import iscoroutinefunction
 import logging
 import hashlib
 import struct
@@ -97,10 +98,12 @@ def _owui_version_ge(threshold: str) -> bool:
 
 
 async def _call_db(method, *args, **kwargs):
-    if _owui_version_ge("0.9.0"):
+    if iscoroutinefunction(method):
         return await method(*args, **kwargs)
-    else:
-        return method(*args, **kwargs)
+    res = method(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        return await res
+    return res
 
 
 _AUTO_URL_RE = re.compile(r"(?:https?://|www\.)[^\s<>()]+")

--- a/plugins/actions/export_to_docx/export_to_word_cn.py
+++ b/plugins/actions/export_to_docx/export_to_word_cn.py
@@ -3,7 +3,7 @@ title: 导出为Word增强版
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 0.5.2
+version: 0.5.3
 required_open_webui_version: 0.10.2
 openwebui_id: 8a6306c0-d005-4e46-aaae-8db3532c9ed5
 icon_url: data:image/svg+xml;base64,PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNNiAyMmEyIDIgMCAwIDEtMi0yVjRhMiAyIDAgMCAxIDItMmg4YTIuNCAyLjQgMCAwIDEgMS43MDQuNzA2bDMuNTg4IDMuNTg4QTIuNCAyLjQgMCAwIDEgMjAgOHYxMmEyIDIgMCAwIDEtMiAyeiIgLz4KICA8cGF0aCBkPSJNMTQgMnY1YTEgMSAwIDAgMCAxIDFoNSIgLz4KICA8cGF0aCBkPSJNMTAgOUg4IiAvPgogIDxwYXRoIGQ9Ik0xNiAxM0g4IiAvPgogIDxwYXRoIGQ9Ik0xNiAxN0g4IiAvPgo8L3N2Zz4K
@@ -20,6 +20,7 @@ import datetime
 import time
 import io
 import asyncio
+from inspect import iscoroutinefunction
 import logging
 import hashlib
 import struct
@@ -98,10 +99,12 @@ def _owui_version_ge(threshold: str) -> bool:
 
 
 async def _call_db(method, *args, **kwargs):
-    if _owui_version_ge("0.9.0"):
+    if iscoroutinefunction(method):
         return await method(*args, **kwargs)
-    else:
-        return method(*args, **kwargs)
+    res = method(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        return await res
+    return res
 
 
 _AUTO_URL_RE = re.compile(r"(?:https?://|www\.)[^\s<>()]+")

--- a/plugins/actions/export_to_docx/v0.5.3.md
+++ b/plugins/actions/export_to_docx/v0.5.3.md
@@ -1,0 +1,20 @@
+# Export to Word Enhanced v0.5.3 Release Notes
+
+## Overview
+
+This patch resolves async database compatibility errors that surfaced on OpenWebUI >= 0.9.0 (including v0.10.1). The previous version-gated dispatch in `_call_db` relied on `_owui_version_ge("0.9.0")`, which can fall back to `"0.0.0"` when the OpenWebUI version import fails inside an isolated plugin sandbox. Under that fallback, async DB methods were invoked synchronously, producing runtime warnings and attribute errors. This release replaces the version-string check with runtime coroutine detection.
+
+## Bug Fixes
+
+- **Runtime coroutine detection for DB methods**: `_call_db` now uses `iscoroutinefunction(method)` (and a secondary `asyncio.iscoroutine(res)` guard for lazy coroutines) to decide whether to `await`. Version-string detection is no longer required.
+- **Resolves `RuntimeWarning: coroutine '_call_db' was never awaited`**
+- **Resolves `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**
+
+## Compatibility
+
+- Behavior is unchanged on OpenWebUI < 0.9.0.
+- No new Valves, no breaking changes.
+
+## Upgrade Notes
+
+Update or reinstall the plugin. No user action beyond reinstall is required.

--- a/plugins/actions/export_to_docx/v0.5.3_CN.md
+++ b/plugins/actions/export_to_docx/v0.5.3_CN.md
@@ -1,0 +1,20 @@
+# 导出为 Word 增强版 v0.5.3 版本发布说明
+
+## 概述
+
+本补丁修复了在 OpenWebUI >= 0.9.0（含 v0.10.1）上出现的异步数据库兼容性错误。此前 `_call_db` 中的版本判断依赖 `_owui_version_ge("0.9.0")`，但在隔离的插件沙箱里 OpenWebUI 版本导入有时会失败并回退到 `"0.0.0"`。回退后，异步 DB 方法被当作同步方法调用，从而产生运行时告警和属性错误。本版本用运行时协程检测替换了版本字符串判断。
+
+## 修复内容
+
+- **DB 方法的运行时协程检测**：`_call_db` 现在用 `iscoroutinefunction(method)`（并对惰性协程增加 `asyncio.iscoroutine(res)` 二次判断）来决定是否 `await`。不再需要版本字符串判断。
+- **解决 `RuntimeWarning: coroutine '_call_db' was never awaited`**
+- **解决 `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**
+
+## 兼容性
+
+- OpenWebUI < 0.9.0 上行为不变。
+- 无新增 Valves、无破坏性变更。
+
+## 升级说明
+
+更新或重新安装插件即可，无需其他操作。

--- a/plugins/actions/export_to_excel/README.md
+++ b/plugins/actions/export_to_excel/README.md
@@ -1,6 +1,6 @@
 # 📊 Export to Excel
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v0.3.10 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v0.3.11 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -66,6 +66,10 @@ If this plugin has been useful, a star on [OpenWebUI Extensions](https://github.
 See the full history on GitHub: [OpenWebUI Extensions](https://github.com/Fu-Jie/openwebui-extensions)# Export to Excel
 
 This plugin allows you to export your chat history to an Excel (.xlsx) file directly from the chat interface.
+
+## What's New in v0.3.11
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` now uses `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated plugin sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## What's New in v0.3.10
 

--- a/plugins/actions/export_to_excel/README_CN.md
+++ b/plugins/actions/export_to_excel/README_CN.md
@@ -1,6 +1,6 @@
 # 📊 导出为 Excel
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.3.10 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.3.11 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## v0.3.11 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的插件沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params'/'email'`。OpenWebUI < 0.9.0 上行为不变。
 
 ## 🔥 v0.3.10 更新内容
 

--- a/plugins/actions/export_to_excel/export_to_excel.py
+++ b/plugins/actions/export_to_excel/export_to_excel.py
@@ -3,7 +3,7 @@ title: Export to Excel
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 0.3.10
+version: 0.3.11
 required_open_webui_version: 0.10.2
 openwebui_id: 244b8f9d-7459-47d6-84d3-c7ae8e3ec710
 icon_url: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik0xNSAySDZhMiAyIDAgMCAwLTIgMnYxNmEyIDIgMCAwIDAgMiAyaDEyYTIgMiAwIDAgMCAyLTJWN1oiLz48cGF0aCBkPSJNMTQgMnY0YTIgMiAwIDAgMCAyIDJoNCIvPjxwYXRoIGQ9Ik04IDEzaDIiLz48cGF0aCBkPSJNMTQgMTNoMiIvPjxwYXRoIGQ9Ik04IDE3aDIiLz48cGF0aCBkPSJNMTQgMTdoMiIvPjwvc3ZnPg==
@@ -18,6 +18,7 @@ from fastapi import FastAPI, HTTPException
 from typing import Optional, Callable, Awaitable, Any, List, Dict
 import datetime
 import asyncio
+from inspect import iscoroutinefunction
 from open_webui.models.chats import Chats
 from open_webui.models.chat_messages import ChatMessages
 from open_webui.models.users import Users
@@ -43,10 +44,12 @@ def _owui_version_ge(threshold: str) -> bool:
 
 
 async def _call_db(method, *args, **kwargs):
-    if _owui_version_ge("0.9.0"):
+    if iscoroutinefunction(method):
         return await method(*args, **kwargs)
-    else:
-        return method(*args, **kwargs)
+    res = method(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        return await res
+    return res
 
 
 app = FastAPI()

--- a/plugins/actions/export_to_excel/export_to_excel_cn.py
+++ b/plugins/actions/export_to_excel/export_to_excel_cn.py
@@ -3,7 +3,7 @@ title: 导出为 Excel
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 0.3.10
+version: 0.3.11
 required_open_webui_version: 0.10.2
 icon_url: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik0xNSAySDZhMiAyIDAgMCAwLTIgMnYxNmEyIDIgMCAwIDAgMiAyaDEyYTIgMiAwIDAgMCAyLTJWN1oiLz48cGF0aCBkPSJNMTQgMnY0YTIgMiAwIDAgMCAyIDJoNCIvPjxwYXRoIGQ9Ik04IDEzaDIiLz48cGF0aCBkPSJNMTQgMTNoMiIvPjxwYXRoIGQ9Ik04IDE3aDIiLz48cGF0aCBkPSJNMTQgMTdoMiIvPjwvc3ZnPg==
 description: 从聊天消息中提取表格并导出为 Excel (.xlsx) 文件，支持智能格式化。
@@ -17,6 +17,7 @@ from fastapi import FastAPI, HTTPException
 from typing import Optional, Callable, Awaitable, Any, List, Dict
 import datetime
 import asyncio
+from inspect import iscoroutinefunction
 from open_webui.models.chats import Chats
 from open_webui.models.chat_messages import ChatMessages
 from open_webui.models.users import Users
@@ -42,10 +43,12 @@ def _owui_version_ge(threshold: str) -> bool:
 
 
 async def _call_db(method, *args, **kwargs):
-    if _owui_version_ge("0.9.0"):
+    if iscoroutinefunction(method):
         return await method(*args, **kwargs)
-    else:
-        return method(*args, **kwargs)
+    res = method(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        return await res
+    return res
 
 
 app = FastAPI()

--- a/plugins/actions/export_to_excel/v0.3.11.md
+++ b/plugins/actions/export_to_excel/v0.3.11.md
@@ -1,0 +1,20 @@
+# Export to Excel v0.3.11 Release Notes
+
+## Overview
+
+This patch resolves async database compatibility errors that surfaced on OpenWebUI >= 0.9.0 (including v0.10.1). The previous version-gated dispatch in `_call_db` relied on `_owui_version_ge("0.9.0")`, which can fall back to `"0.0.0"` when the OpenWebUI version import fails inside an isolated plugin sandbox. Under that fallback, async DB methods were invoked synchronously, producing runtime warnings and attribute errors. This release replaces the version-string check with runtime coroutine detection.
+
+## Bug Fixes
+
+- **Runtime coroutine detection for DB methods**: `_call_db` now uses `iscoroutinefunction(method)` (and a secondary `asyncio.iscoroutine(res)` guard for lazy coroutines) to decide whether to `await`. Version-string detection is no longer required.
+- **Resolves `RuntimeWarning: coroutine '_call_db' was never awaited`**
+- **Resolves `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**
+
+## Compatibility
+
+- Behavior is unchanged on OpenWebUI < 0.9.0.
+- No new Valves, no breaking changes.
+
+## Upgrade Notes
+
+Update or reinstall the plugin. No user action beyond reinstall is required.

--- a/plugins/actions/export_to_excel/v0.3.11_CN.md
+++ b/plugins/actions/export_to_excel/v0.3.11_CN.md
@@ -1,0 +1,20 @@
+# 导出为 Excel v0.3.11 版本发布说明
+
+## 概述
+
+本补丁修复了在 OpenWebUI >= 0.9.0（含 v0.10.1）上出现的异步数据库兼容性错误。此前 `_call_db` 中的版本判断依赖 `_owui_version_ge("0.9.0")`，但在隔离的插件沙箱里 OpenWebUI 版本导入有时会失败并回退到 `"0.0.0"`。回退后，异步 DB 方法被当作同步方法调用，从而产生运行时告警和属性错误。本版本用运行时协程检测替换了版本字符串判断。
+
+## 修复内容
+
+- **DB 方法的运行时协程检测**：`_call_db` 现在用 `iscoroutinefunction(method)`（并对惰性协程增加 `asyncio.iscoroutine(res)` 二次判断）来决定是否 `await`。不再需要版本字符串判断。
+- **解决 `RuntimeWarning: coroutine '_call_db' was never awaited`**
+- **解决 `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**
+
+## 兼容性
+
+- OpenWebUI < 0.9.0 上行为不变。
+- 无新增 Valves、无破坏性变更。
+
+## 升级说明
+
+更新或重新安装插件即可，无需其他操作。

--- a/plugins/actions/flash-card/README.md
+++ b/plugins/actions/flash-card/README.md
@@ -2,7 +2,7 @@
 
 Generate polished learning flashcards from any text—title, summary, key points, tags, and category—ready for review and sharing.
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v0.2.4 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v0.2.5 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## What's New in v0.2.5
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `Users.get_user_by_id` was previously called without `await`, which returned a coroutine object instead of the user row on OWUI >= 0.9.0, causing `AttributeError: 'coroutine' object has no attribute 'email'`. The call is now wrapped in a new `_call_db` helper that uses `iscoroutinefunction` + `asyncio.iscoroutine` for runtime async detection. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## What's New
 

--- a/plugins/actions/flash-card/README_CN.md
+++ b/plugins/actions/flash-card/README_CN.md
@@ -2,7 +2,7 @@
 
 快速将文本提炼为精美的学习记忆卡片，自动抽取标题、摘要、关键要点、标签和分类，适合复习与分享。
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.2.4 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v0.2.5 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## v0.2.5 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：此前 `Users.get_user_by_id` 直接调用没有 `await`，在 OWUI >= 0.9.0 上返回的是协程对象而非用户记录，导致 `AttributeError: 'coroutine' object has no attribute 'email'`。现在已用新增的 `_call_db` helper 包装，该 helper 通过 `iscoroutinefunction` + `asyncio.iscoroutine` 进行运行时异步检测。OpenWebUI < 0.9.0 上行为不变。
 
 ## 🔥 最新更新 v0.2.4
 

--- a/plugins/actions/flash-card/flash_card.py
+++ b/plugins/actions/flash-card/flash_card.py
@@ -3,7 +3,7 @@ title: Flash Card
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 0.2.4
+version: 0.2.5
 openwebui_id: 65a2ea8f-2a13-4587-9d76-55eea0035cc8
 icon_url: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwb2x5Z29uIHBvaW50cz0iMTIgMiAyIDcgMTIgMTIgMjIgNyAxMiAyIi8+PHBvbHlsaW5lIHBvaW50cz0iMiAxNyAxMiAyMiAyMiAxNyIvPjxwb2x5bGluZSBwb2ludHM9IjIgMTIgMTIgMTcgMjIgMTIiLz48L3N2Zz4=
 description: Quickly generates beautiful flashcards from text, extracting key points and categories.
@@ -16,6 +16,18 @@ import logging
 import re
 from open_webui.utils.chat import generate_chat_completion
 from open_webui.models.users import Users
+import asyncio
+from inspect import iscoroutinefunction
+
+
+async def _call_db(method, *args, **kwargs):
+    if iscoroutinefunction(method):
+        return await method(*args, **kwargs)
+    res = method(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        return await res
+    return res
+
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -223,7 +235,7 @@ class Action:
 
             user_ctx = self._get_user_context(__user__)
             user_id = user_ctx["user_id"]
-            user_obj = Users.get_user_by_id(user_id)
+            user_obj = await _call_db(Users.get_user_by_id, user_id)
 
             target_model = (
                 self.valves.MODEL_ID if self.valves.MODEL_ID else body.get("model")

--- a/plugins/actions/flash-card/flash_card_cn.py
+++ b/plugins/actions/flash-card/flash_card_cn.py
@@ -3,7 +3,7 @@ title: 闪记卡 (Flash Card)
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 0.2.4
+version: 0.2.5
 openwebui_id: 4a31eac3-a3c4-4c30-9ca5-dab36b5fac65
 icon_url: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwb2x5Z29uIHBvaW50cz0iMTIgMiAyIDcgMTIgMTIgMjIgNyAxMiAyIi8+PHBvbHlsaW5lIHBvaW50cz0iMiAxNyAxMiAyMiAyMiAxNyIvPjxwb2x5bGluZSBwb2ludHM9IjIgMTIgMTIgMTcgMjIgMTIiLz48L3N2Zz4=
 description: 快速将文本提炼为精美的学习记忆卡片，支持核心要点提取与分类。
@@ -16,6 +16,18 @@ import logging
 import re
 from open_webui.utils.chat import generate_chat_completion
 from open_webui.models.users import Users
+import asyncio
+from inspect import iscoroutinefunction
+
+
+async def _call_db(method, *args, **kwargs):
+    if iscoroutinefunction(method):
+        return await method(*args, **kwargs)
+    res = method(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        return await res
+    return res
+
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -214,7 +226,7 @@ class Action:
 
             user_ctx = self._get_user_context(__user__)
             user_id = user_ctx["user_id"]
-            user_obj = Users.get_user_by_id(user_id)
+            user_obj = await _call_db(Users.get_user_by_id, user_id)
 
             target_model = (
                 self.valves.MODEL_ID if self.valves.MODEL_ID else body.get("model")

--- a/plugins/actions/flash-card/v0.2.5.md
+++ b/plugins/actions/flash-card/v0.2.5.md
@@ -1,0 +1,20 @@
+# Flash Card v0.2.5 Release Notes
+
+## Overview
+
+This patch resolves an async database compatibility error that surfaced on OpenWebUI >= 0.9.0 (including v0.10.1). Unlike other plugins that already had a `_call_db` helper, Flash Card called `Users.get_user_by_id()` directly without `await`. On OWUI >= 0.9.0 where DB methods are async coroutines, this returned a coroutine object instead of the user row, causing `AttributeError: 'coroutine' object has no attribute 'email'`. This release introduces a `_call_db` helper with runtime coroutine detection and wraps the DB call with it.
+
+## Bug Fixes
+
+- **Introduced `_call_db` helper**: A new `_call_db` helper using `iscoroutinefunction(method)` + `asyncio.iscoroutine(res)` now handles the sync/async dispatch for DB method calls.
+- **Wrapped `Users.get_user_by_id` with `await _call_db(...)`**: The call is now properly awaited on async runtimes and called directly on sync runtimes.
+- **Resolves `AttributeError: 'coroutine' object has no attribute 'email'`**
+
+## Compatibility
+
+- Behavior is unchanged on OpenWebUI < 0.9.0 (sync DB methods are called directly; `iscoroutinefunction` returns `False`).
+- No new Valves, no breaking changes.
+
+## Upgrade Notes
+
+Update or reinstall the plugin. No user action beyond reinstall is required.

--- a/plugins/actions/flash-card/v0.2.5_CN.md
+++ b/plugins/actions/flash-card/v0.2.5_CN.md
@@ -1,0 +1,20 @@
+# 闪记卡 v0.2.5 版本发布说明
+
+## 概述
+
+本补丁修复了在 OpenWebUI >= 0.9.0（含 v0.10.1）上出现的异步数据库兼容性错误。与其他已有 `_call_db` helper 的插件不同，闪记卡此前直接调用 `Users.get_user_by_id()` 且没有 `await`。在 OWUI >= 0.9.0 上 DB 方法是异步协程，直接调用返回的是协程对象而非用户记录，导致 `AttributeError: 'coroutine' object has no attribute 'email'`。本版本引入了 `_call_db` helper（运行时协程检测）并用它包装了 DB 调用。
+
+## 修复内容
+
+- **引入 `_call_db` helper**：新增的 `_call_db` helper 使用 `iscoroutinefunction(method)` + `asyncio.iscoroutine(res)` 处理同步/异步派发。
+- **用 `await _call_db(...)` 包装 `Users.get_user_by_id`**：在异步运行时上正确 await，在同步运行时上直接调用。
+- **解决 `AttributeError: 'coroutine' object has no attribute 'email'`**
+
+## 兼容性
+
+- OpenWebUI < 0.9.0 上行为不变（同步 DB 方法仍直接调用；`iscoroutinefunction` 返回 `False`）。
+- 无新增 Valves、无破坏性变更。
+
+## 升级说明
+
+更新或重新安装插件即可，无需其他操作。

--- a/plugins/actions/infographic/README.md
+++ b/plugins/actions/infographic/README.md
@@ -1,6 +1,6 @@
 # Smart Infographic
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v1.6.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v1.6.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## What's New in v1.6.3
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` now uses `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated plugin sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## 🔥 What's New in v1.6.2
 

--- a/plugins/actions/infographic/README_CN.md
+++ b/plugins/actions/infographic/README_CN.md
@@ -1,6 +1,6 @@
 # 智能信息图
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.6.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.6.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -20,6 +20,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## v1.6.3 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的插件沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params'/'email'`。OpenWebUI < 0.9.0 上行为不变。
 
 ## 🔥 最新更新 v1.6.2
 

--- a/plugins/actions/infographic/infographic.py
+++ b/plugins/actions/infographic/infographic.py
@@ -4,7 +4,7 @@ author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
 icon_url: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPgogIDxsaW5lIHgxPSIxMiIgeTE9IjIwIiB4Mj0iMTIiIHkyPSIxMCIgLz4KICA8bGluZSB4MT0iMTgiIHkxPSIyMCIgeDI9IjE4IiB5Mj0iNCIgLz4KICA8bGluZSB4MT0iNiIgeTE9IjIwIiB4Mj0iNiIgeTI9IjE2IiAvPgo8L3N2Zz4=
-version: 1.6.2
+version: 1.6.3
 openwebui_id: ad6f0c7f-c571-4dea-821d-8e71697274cf
 description: AI-powered infographic generator based on AntV Infographic. Supports professional templates, auto-icon matching, and SVG/PNG downloads.
 """
@@ -17,6 +17,7 @@ import re
 from fastapi import Request
 from datetime import datetime
 import asyncio
+from inspect import iscoroutinefunction
 
 from open_webui.utils.chat import generate_chat_completion
 from open_webui.models.users import Users
@@ -38,10 +39,12 @@ def _owui_version_ge(threshold: str) -> bool:
 
 
 async def _call_db(method, *args, **kwargs):
-    if _owui_version_ge("0.9.0"):
+    if iscoroutinefunction(method):
         return await method(*args, **kwargs)
-    else:
-        return method(*args, **kwargs)
+    res = method(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        return await res
+    return res
 
 
 logging.basicConfig(

--- a/plugins/actions/infographic/v1.6.3.md
+++ b/plugins/actions/infographic/v1.6.3.md
@@ -1,0 +1,20 @@
+# Infographic v1.6.3 Release Notes
+
+## Overview
+
+This patch resolves async database compatibility errors that surfaced on OpenWebUI >= 0.9.0 (including v0.10.1). The previous version-gated dispatch in `_call_db` relied on `_owui_version_ge("0.9.0")`, which can fall back to `"0.0.0"` when the OpenWebUI version import fails inside an isolated plugin sandbox. Under that fallback, async DB methods were invoked synchronously, producing runtime warnings and attribute errors. This release replaces the version-string check with runtime coroutine detection.
+
+## Bug Fixes
+
+- **Runtime coroutine detection for DB methods**: `_call_db` now uses `iscoroutinefunction(method)` (and a secondary `asyncio.iscoroutine(res)` guard for lazy coroutines) to decide whether to `await`. Version-string detection is no longer required.
+- **Resolves `RuntimeWarning: coroutine '_call_db' was never awaited`**
+- **Resolves `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**
+
+## Compatibility
+
+- Behavior is unchanged on OpenWebUI < 0.9.0.
+- No new Valves, no breaking changes.
+
+## Upgrade Notes
+
+Update or reinstall the plugin. No user action beyond reinstall is required.

--- a/plugins/actions/infographic/v1.6.3_CN.md
+++ b/plugins/actions/infographic/v1.6.3_CN.md
@@ -1,0 +1,20 @@
+# 信息图 v1.6.3 版本发布说明
+
+## 概述
+
+本补丁修复了在 OpenWebUI >= 0.9.0（含 v0.10.1）上出现的异步数据库兼容性错误。此前 `_call_db` 中的版本判断依赖 `_owui_version_ge("0.9.0")`，但在隔离的插件沙箱里 OpenWebUI 版本导入有时会失败并回退到 `"0.0.0"`。回退后，异步 DB 方法被当作同步方法调用，从而产生运行时告警和属性错误。本版本用运行时协程检测替换了版本字符串判断。
+
+## 修复内容
+
+- **DB 方法的运行时协程检测**：`_call_db` 现在用 `iscoroutinefunction(method)`（并对惰性协程增加 `asyncio.iscoroutine(res)` 二次判断）来决定是否 `await`。不再需要版本字符串判断。
+- **解决 `RuntimeWarning: coroutine '_call_db' was never awaited`**
+- **解决 `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**
+
+## 兼容性
+
+- OpenWebUI < 0.9.0 上行为不变。
+- 无新增 Valves、无破坏性变更。
+
+## 升级说明
+
+更新或重新安装插件即可，无需其他操作。

--- a/plugins/actions/smart-mind-map/README.md
+++ b/plugins/actions/smart-mind-map/README.md
@@ -2,7 +2,7 @@
 
 Smart Mind Map is a powerful OpenWebUI action plugin that intelligently analyzes long-form text content and automatically generates interactive mind maps, helping users structure and visualize knowledge.
 
-| By [Fu-Jie](https://github.com/Fu-Jie) · v1.0.2 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
+| By [Fu-Jie](https://github.com/Fu-Jie) · v1.0.3 | [⭐ Star this repo](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -22,6 +22,10 @@ When the selection dialog opens, search for this plugin, check it, and continue.
 
 > [!IMPORTANT]
 > If the official OpenWebUI Community version is already installed, remove it first. After that, Batch Install Plugins can keep this plugin updated in future runs.
+
+## What's New in v1.0.3
+
+- **Async DB compatibility on OpenWebUI >= 0.9.0 / v0.10.1**: `_call_db` now uses `iscoroutinefunction` + `asyncio.iscoroutine` to detect whether a DB method is async, instead of relying on `_owui_version_ge("0.9.0")`. In isolated plugin sandboxes the version import can fall back to `"0.0.0"`, which previously caused async DB methods to be called synchronously. This resolves `RuntimeWarning: coroutine '_call_db' was never awaited` and `AttributeError: 'coroutine' object has no attribute 'params'/'email'`. Behavior on OpenWebUI < 0.9.0 is unchanged.
 
 ## What's New in v1.0.2
 

--- a/plugins/actions/smart-mind-map/README_CN.md
+++ b/plugins/actions/smart-mind-map/README_CN.md
@@ -2,7 +2,7 @@
 
 思维导图是一个强大的 OpenWebUI 动作插件，能够智能分析长篇文本内容，自动生成交互式思维导图，帮助用户结构化和可视化知识。
 
-| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.0.2 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
+| 作者：[Fu-Jie](https://github.com/Fu-Jie) · v1.0.3 | [⭐ 点个 Star 支持项目](https://github.com/Fu-Jie/openwebui-extensions) |
 | :--- | ---: |
 
 | ![followers](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_followers.json&label=%F0%9F%91%A5&style=flat) | ![points](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_points.json&label=%E2%AD%90&style=flat) | ![top](https://img.shields.io/badge/%F0%9F%8F%86-Top%20%3C1%25-10b981?style=flat) | ![contributions](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_contributions.json&label=%F0%9F%93%A6&style=flat) | ![downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_downloads.json&label=%E2%AC%87%EF%B8%8F&style=flat) | ![saves](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_saves.json&label=%F0%9F%92%BE&style=flat) | ![views](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2FFu-Jie%2Fdb3d95687075a880af6f1fba76d679c6%2Fraw%2Fbadge_views.json&label=%F0%9F%91%81%EF%B8%8F&style=flat) |
@@ -22,6 +22,10 @@
 
 > [!IMPORTANT]
 > 如果你已经安装了 OpenWebUI 官方社区里的同名版本，请先删除旧版本，否则重新安装时可能报错。删除后，Batch Install Plugins 后续就可以继续负责更新这个插件。
+
+## v1.0.3 最新更新
+
+- **OpenWebUI >= 0.9.0 / v0.10.1 上的异步 DB 兼容性**：`_call_db` 现在用 `iscoroutinefunction` + `asyncio.iscoroutine` 检测 DB 方法是否为异步，不再依赖 `_owui_version_ge("0.9.0")`。在隔离的插件沙箱里版本导入有时会回退到 `"0.0.0"`，此前会导致异步 DB 方法被同步调用。本版本解决 `RuntimeWarning: coroutine '_call_db' was never awaited` 和 `AttributeError: 'coroutine' object has no attribute 'params'/'email'`。OpenWebUI < 0.9.0 上行为不变。
 
 ## v1.0.2 最新更新
 

--- a/plugins/actions/smart-mind-map/smart_mind_map.py
+++ b/plugins/actions/smart-mind-map/smart_mind_map.py
@@ -3,7 +3,7 @@ title: Smart Mind Map
 author: Fu-Jie
 author_url: https://github.com/Fu-Jie/openwebui-extensions
 funding_url: https://github.com/open-webui
-version: 1.0.2
+version: 1.0.3
 required_open_webui_version: 0.10.2
 openwebui_id: 3094c59a-b4dd-4e0c-9449-15e2dd547dc4
 icon_url: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjYiIGhlaWdodD0iNiIgcng9IjEiLz48cmVjdCB4PSIyIiB5PSIxNiIgd2lkdGg9IjYiIGhlaWdodD0iNiIgcng9IjEiLz48cmVjdCB4PSI5IiB5PSIyIiB3aWR0aD0iNiIgaGVpZ2h0PSI2IiByeD0iMSIvPjxwYXRoIGQ9Ik01IDE2di0zYTEgMSAwIDAgMSAxLTFoMTJhMSAxIDAgMCAxIDEgMXYzIi8+PHBhdGggZD0iTTEyIDEyVjgiLz48L3N2Zz4=
@@ -11,6 +11,7 @@ description: Intelligently analyzes text content and generates interactive mind 
 """
 
 import asyncio
+from inspect import iscoroutinefunction
 import logging
 import os
 import re
@@ -55,10 +56,12 @@ def _owui_version_ge(threshold: str) -> bool:
 
 
 async def _call_db(method, *args, **kwargs):
-    if _owui_version_ge("0.9.0"):
+    if iscoroutinefunction(method):
         return await method(*args, **kwargs)
-    else:
-        return method(*args, **kwargs)
+    res = method(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        return await res
+    return res
 
 
 logging.basicConfig(

--- a/plugins/actions/smart-mind-map/v1.0.3.md
+++ b/plugins/actions/smart-mind-map/v1.0.3.md
@@ -1,0 +1,20 @@
+# Smart Mind Map v1.0.3 Release Notes
+
+## Overview
+
+This patch resolves async database compatibility errors that surfaced on OpenWebUI >= 0.9.0 (including v0.10.1). The previous version-gated dispatch in `_call_db` relied on `_owui_version_ge("0.9.0")`, which can fall back to `"0.0.0"` when the OpenWebUI version import fails inside an isolated plugin sandbox. Under that fallback, async DB methods were invoked synchronously, producing runtime warnings and attribute errors. This release replaces the version-string check with runtime coroutine detection.
+
+## Bug Fixes
+
+- **Runtime coroutine detection for DB methods**: `_call_db` now uses `iscoroutinefunction(method)` (and a secondary `asyncio.iscoroutine(res)` guard for lazy coroutines) to decide whether to `await`. Version-string detection is no longer required.
+- **Resolves `RuntimeWarning: coroutine '_call_db' was never awaited`**
+- **Resolves `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**
+
+## Compatibility
+
+- Behavior is unchanged on OpenWebUI < 0.9.0.
+- No new Valves, no breaking changes. The v1.0.2 OWUI v0.10+ content-recovery fix is preserved.
+
+## Upgrade Notes
+
+Update or reinstall the plugin. No user action beyond reinstall is required.

--- a/plugins/actions/smart-mind-map/v1.0.3_CN.md
+++ b/plugins/actions/smart-mind-map/v1.0.3_CN.md
@@ -1,0 +1,20 @@
+# 智能思维导图 v1.0.3 版本发布说明
+
+## 概述
+
+本补丁修复了在 OpenWebUI >= 0.9.0（含 v0.10.1）上出现的异步数据库兼容性错误。此前 `_call_db` 中的版本判断依赖 `_owui_version_ge("0.9.0")`，但在隔离的插件沙箱里 OpenWebUI 版本导入有时会失败并回退到 `"0.0.0"`。回退后，异步 DB 方法被当作同步方法调用，从而产生运行时告警和属性错误。本版本用运行时协程检测替换了版本字符串判断。
+
+## 修复内容
+
+- **DB 方法的运行时协程检测**：`_call_db` 现在用 `iscoroutinefunction(method)`（并对惰性协程增加 `asyncio.iscoroutine(res)` 二次判断）来决定是否 `await`。不再需要版本字符串判断。
+- **解决 `RuntimeWarning: coroutine '_call_db' was never awaited`**
+- **解决 `AttributeError: 'coroutine' object has no attribute 'params'` / `'email'`**
+
+## 兼容性
+
+- OpenWebUI < 0.9.0 上行为不变。
+- 无新增 Valves、无破坏性变更。v1.0.2 的 OWUI v0.10+ 内容恢复修复保持不变。
+
+## 升级说明
+
+更新或重新安装插件即可，无需其他操作。


### PR DESCRIPTION
## Summary

Unifies the async DB compatibility fix across 5 action plugins that have `openwebui_id` metadata. Follows the same approach as #107 (async-context-compression) — replace fragile version-string detection with runtime coroutine detection.

## Background

OWUI >= 0.9.0 turned `Users.get_user_by_id`, `Chats.get_chat_by_id`, `Models.get_model_by_id` into coroutines. The previous `_owui_version_ge("0.9.0")` guard is unreliable in isolated filter/action sandboxes: `from open_webui.env import VERSION` can fail and fall back to `"0.0.0"`, causing async methods to be called synchronously and raising `TypeError: object coroutine can't be used in 'await'`. Originally reported in #101.

## Fix

`_call_db` now uses `iscoroutinefunction(method)` + `asyncio.iscoroutine(res)` instead of version-string comparison:

```python
async def _call_db(method, *args, **kwargs):
    if iscoroutinefunction(method):
        return await method(*args, **kwargs)
    res = method(*args, **kwargs)
    if asyncio.iscoroutine(res):
        return await res
    return res
```

## Two bug patterns

**Class A — existing `_call_db` using version-string check (6 files):**
- `export_to_docx` — `export_to_word.py`, `export_to_word_cn.py`
- `smart-mind-map` — `smart_mind_map.py`
- `infographic` — `infographic.py`
- `export_to_excel` — `export_to_excel.py`, `export_to_excel_cn.py`

**Class B — no `_call_db` helper, called `Users.get_user_by_id()` synchronously (2 files):**
- `flash-card` — `flash_card.py`, `flash_card_cn.py` (added helper + wrapped call)

## Version bumps

| Plugin | Old | New |
|---|---|---|
| smart-mind-map | 1.0.2 | 1.0.3 |
| infographic | 1.6.2 | 1.6.3 |
| flash-card | 0.2.4 | 0.2.5 |
| export_to_excel | 0.3.10 | 0.3.11 |
| export_to_docx | 0.5.2 | 0.5.3 |

## Docs

- Bilingual release notes (`v{version}.md` + `v{version}_CN.md`) for all 5 plugins
- README / README_CN updated with version badges + What's New sections
- `docs/plugins/actions/index.md` and `index.zh.md` version fields updated
- Stale version-badges in `smart-infographic.md`, `smart-infographic.zh.md`, `export-to-word.md`, `export-to-word.zh.md` bumped

## Note on check_version_consistency.py

The script reports 2 false positives (`export_to_excel_cn.py` and `export_to_word_cn.py`) because its regex `version:` also matches `required_open_webui_version: 0.10.2`. Running `--fix` would corrupt that line, so I left the script alone. The actual `version:` metadata in all 8 .py files is correct.

Refs: #101, #107